### PR TITLE
feat: modernize chat agent with tool-calling, HyDE, and improved UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Typecheck Convex
-        run: bunx tsc --noEmit -p convex/tsconfig.json
+        run: bun run typecheck:convex
 
       - name: Build Web
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Git worktrees
+.worktrees/
+
 # Logs
 logs
 *.log

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,7 +37,7 @@ import { useNotebooks, useCreateNotebook, useUpdateNotebook, useDeleteNotebook }
 import { useFolders, useCreateFolder, useUpdateFolder, useDeleteFolder } from './features/notebooks/services/foldersApi';
 import { useGenerateUploadUrl, useCreateDocument, useUpdateDocument, useDeleteDocument } from './features/sources/services/documentsApi';
 import { useSubscriptionStatus } from './features/billing/services/subscriptionApi';
-import { useSendMessage } from './features/chat/services/chatApi';
+import { useSendMessage, useSetMessageFeedback } from './features/chat/services/chatApi';
 import { useLimitErrorToast } from './shared/hooks/useLimitErrorToast';
 import 'mind-elixir/style.css';
 
@@ -214,6 +214,8 @@ const AppContent: React.FC = () => {
   const [streamingContent, setStreamingContent] = useState('');
   const [streamingReferences, setStreamingReferences] = useState<unknown[] | null>(null);
   const [streamingJustFinished, setStreamingJustFinished] = useState(false);
+  const [streamingToolCalls, setStreamingToolCalls] = useState<import('./shared/types/index').MessageToolCall[]>([]);
+  const [lastAssistantFollowUps, setLastAssistantFollowUps] = useState<string[] | null>(null);
   const messagesLengthWhenStreamCompleteRef = useRef(0);
 
   // Mini Audio Player state
@@ -239,6 +241,7 @@ const AppContent: React.FC = () => {
 
   // Chat: stream messages with optimistic updates
   const sendChatMessage = useSendMessage();
+  const setMessageFeedback = useSetMessageFeedback();
 
   // Filter notebooks for home page (notebooks may be undefined while loading)
   const notebookList = notebooks ?? [];
@@ -328,16 +331,21 @@ const AppContent: React.FC = () => {
       .filter((source) => source.selected)
       .map((source) => source.id);
 
+    setStreamingToolCalls([]);
+    setLastAssistantFollowUps(null);
+
     const clearStreaming = () => {
       setIsChatStreaming(false);
       setStreamingContent('');
       setStreamingReferences(null);
       setStreamingJustFinished(false);
+      setStreamingToolCalls([]);
     };
 
     const onStreamComplete = () => {
       setIsChatStreaming(false);
       setStreamingJustFinished(true);
+      setStreamingToolCalls([]);
       messagesLengthWhenStreamCompleteRef.current = messages.length;
     };
 
@@ -349,6 +357,16 @@ const AppContent: React.FC = () => {
           onToken: (token) => setStreamingContent((prev) => prev + token),
           onReferences: (refs) => setStreamingReferences(refs),
           onStatus: () => {},
+          onToolCall: (tc) => setStreamingToolCalls((prev) => {
+            const existing = prev.findIndex((c) => c.query === tc.query && c.tool === tc.tool);
+            if (existing >= 0) {
+              const next = [...prev];
+              next[existing] = tc;
+              return next;
+            }
+            return [...prev, tc];
+          }),
+          onFollowUps: (qs) => setLastAssistantFollowUps(qs),
           onComplete: onStreamComplete,
           onError: clearStreaming,
         },
@@ -374,24 +392,34 @@ const AppContent: React.FC = () => {
 
   // Chat list: DB messages + in-flight streaming assistant message so tokens appear as they arrive
   const chatDisplayMessages = useMemo((): Message[] => {
-    const list: Message[] = messages.map((msg: Doc<'messages'>) => ({
+    const list: Message[] = messages.map((msg: Doc<'messages'>, index: number) => ({
       id: msg._id,
       role: msg.role as 'user' | 'assistant',
       content: msg.content,
       timestamp: new Date(msg.createdAt as number),
       references: msg.references,
+      feedback: (msg as any).feedback as 'up' | 'down' | undefined,
+      // Attach follow-ups to last DB assistant message when stream just finished
+      followUps: (
+        !streamingContent &&
+        msg.role === 'assistant' &&
+        index === messages.length - 1 &&
+        lastAssistantFollowUps
+      ) ? lastAssistantFollowUps : undefined,
     }));
-    if (streamingContent) {
+    if (isChatStreaming || streamingContent) {
       list.push({
         id: '__streaming__',
         role: 'assistant',
         content: streamingContent,
         timestamp: new Date(),
         references: (streamingReferences as Message['references']) ?? undefined,
+        toolCalls: streamingToolCalls.length > 0 ? streamingToolCalls : undefined,
+        status: streamingContent ? undefined : 'thinking',
       });
     }
     return list;
-  }, [messages, streamingContent, streamingReferences]);
+  }, [messages, streamingContent, streamingReferences, streamingToolCalls, lastAssistantFollowUps, isChatStreaming]);
 
   const handleToggleSource = (id: string) => {
     setSources(prev => prev.map(source =>
@@ -979,6 +1007,7 @@ const AppContent: React.FC = () => {
                     notebookId={activeNotebookId}
                     notebookTitle={notebookTitle}
                     onSaveChatOptimistic={setOptimisticSaveNote}
+                    onSetFeedback={setMessageFeedback}
                   />
 
                   {isStudioOpen && (
@@ -1046,6 +1075,7 @@ const AppContent: React.FC = () => {
                         notebookId={activeNotebookId}
                         notebookTitle={notebookTitle}
                         onSaveChatOptimistic={setOptimisticSaveNote}
+                        onSetFeedback={setMessageFeedback}
                       />
                     </div>
                   )}

--- a/apps/web/src/features/chat/components/ChatEmptyState.tsx
+++ b/apps/web/src/features/chat/components/ChatEmptyState.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { BookOpen } from 'lucide-react';
+
+const STARTER_PROMPTS = [
+  'Summarize the key concepts',
+  'What are the main arguments?',
+  'Quiz me on this material',
+  'Explain the most important topic simply',
+];
+
+interface ChatEmptyStateProps {
+  onSendMessage: (text: string) => void;
+  disabled?: boolean;
+}
+
+export const ChatEmptyState: React.FC<ChatEmptyStateProps> = ({ onSendMessage, disabled }) => (
+  <div className="flex flex-col items-center justify-center h-full px-6 pb-32 gap-6 select-none">
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="p-3 rounded-full bg-primary/10">
+        <BookOpen className="w-6 h-6 text-primary" />
+      </div>
+      <h2 className="font-sans font-semibold text-lg text-foreground">
+        Ask anything about your sources
+      </h2>
+      <p className="text-sm text-muted-foreground max-w-xs">
+        I'll search your uploaded documents and answer with citations.
+      </p>
+    </div>
+    <div className="flex flex-wrap gap-2 justify-center max-w-md">
+      {STARTER_PROMPTS.map((prompt) => (
+        <button
+          key={prompt}
+          type="button"
+          disabled={disabled}
+          onClick={() => onSendMessage(prompt)}
+          className="px-4 py-2 rounded-full border border-border bg-card hover:bg-accent text-sm text-foreground transition-colors font-sans disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {prompt}
+        </button>
+      ))}
+    </div>
+  </div>
+);

--- a/apps/web/src/features/chat/components/ChatInput.tsx
+++ b/apps/web/src/features/chat/components/ChatInput.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useEffect, useCallback } from 'react';
+import { ArrowUp, Loader2 } from 'lucide-react';
+
+interface ChatInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  disabled?: boolean;
+  notebookId?: string | null;
+}
+
+export const ChatInput: React.FC<ChatInputProps> = ({ value, onChange, onSend, disabled, notebookId }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+    }
+  }, [value]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        onSend();
+      }
+    },
+    [onSend]
+  );
+
+  return (
+    <div className="w-full max-w-3xl xl:max-w-4xl 2xl:max-w-5xl bg-card border-2 border-border shadow-lg rounded-2xl py-1.5 px-2 flex flex-col gap-1 relative">
+      <textarea
+        ref={textareaRef}
+        placeholder="Ask a question about your sources..."
+        className="w-full bg-transparent border-none py-2 px-3 resize-none outline-none text-foreground placeholder:text-muted-foreground/70 min-h-[44px] max-h-[160px] font-serif text-lg"
+        rows={1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      <div className="flex justify-end items-center px-1.5 pb-0.5">
+        <button
+          onClick={onSend}
+          disabled={!value.trim() || disabled || !notebookId}
+          className="p-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-all shadow-md active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          title={value.trim() ? 'Send message (Enter)' : 'Type a message to send'}
+        >
+          {disabled ? <Loader2 className="w-5 h-5 animate-spin" /> : <ArrowUp className="w-5 h-5" />}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/chat/components/ChatPanel.tsx
+++ b/apps/web/src/features/chat/components/ChatPanel.tsx
@@ -1,18 +1,25 @@
-import React, { useState, useRef, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
-import { ArrowUp, PanelLeftOpen, PanelRightOpen, MessageCircle, RefreshCw, Loader2, Search, FileText, Brain, Copy, Check, MoreVertical, Download } from 'lucide-react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  PanelLeftOpen,
+  PanelRightOpen,
+  MessageCircle,
+  RefreshCw,
+  FileText,
+  MoreVertical,
+  Download,
+} from 'lucide-react';
 import { useConfirmDialog } from '@/shared/ui/ConfirmDialog';
 import { DropdownMenu } from '@/shared/ui/DropdownMenu';
 import { Virtuoso } from 'react-virtuoso';
 import { Message, Note } from '@/shared/types/index';
-import { sanitizeMarkdown } from '@/shared/utils';
 import { useToast } from '@/shared/contexts/ToastContext';
 import { exportAsMarkdown } from '../utils/exportChat';
-import { replaceCitationMarkersOutsideMath } from '../utils/citationMarkers';
 import { useSaveChat } from '../services/userNotesApi';
-
-const MarkdownRenderer = lazy(() =>
-  import('@/shared/components/MarkdownRenderer').then((m) => ({ default: m.default }))
-);
+import { RefHandlers } from '../utils/messageRendering';
+import { MessageBubble } from './MessageBubble';
+import { ReferenceTooltip } from './ReferenceTooltip';
+import { ChatEmptyState } from './ChatEmptyState';
+import { ChatInput } from './ChatInput';
 
 interface ChatPanelProps {
   messages: Message[];
@@ -27,6 +34,7 @@ interface ChatPanelProps {
   notebookTitle?: string;
   /** Optimistic UI: set when save starts, clear when save ends (success or failure). No toasts. */
   onSaveChatOptimistic?: (payload: { notebookId: string; note: Note } | null) => void;
+  onSetFeedback?: (messageId: string, feedback: 'up' | 'down' | null) => void;
 }
 
 export const ChatPanel: React.FC<ChatPanelProps> = ({
@@ -41,6 +49,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   notebookId,
   notebookTitle = 'Chat',
   onSaveChatOptimistic,
+  onSetFeedback,
 }) => {
   const [hoveredRefId, setHoveredRefId] = useState<number | null>(null);
   const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null);
@@ -52,7 +61,6 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const hideTooltipTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const virtuosoRef = useRef<any>(null);
@@ -61,35 +69,26 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const { success, error: toastError } = useToast();
   const saveChat = useSaveChat();
 
+  // --- Chat action handlers ---
+
   const handleDeleteHistory = async () => {
     const confirmed = await confirm(
       'Clear Chat History',
       'Are you sure you want to delete all chat history? This action cannot be undone.',
       { confirmText: 'Clear History', cancelText: 'Cancel', variant: 'danger' }
     );
-    if (confirmed) {
-      onClearHistory?.();
-    }
+    if (confirmed) onClearHistory?.();
   };
 
   const handleExportChat = () => {
-    if (messages.length === 0) {
-      toastError('No messages to export');
-      return;
-    }
+    if (messages.length === 0) { toastError('No messages to export'); return; }
     exportAsMarkdown(messages, notebookTitle);
     success('Chat exported successfully');
   };
 
   const handleSaveToNote = async () => {
-    if (messages.length === 0) {
-      toastError('No messages to save');
-      return;
-    }
-    if (!notebookId) {
-      toastError('No notebook selected');
-      return;
-    }
+    if (messages.length === 0) { toastError('No messages to save'); return; }
+    if (!notebookId) { toastError('No notebook selected'); return; }
 
     const placeholderNote: Note = {
       id: `pending-save-${Date.now()}`,
@@ -100,24 +99,15 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       status: 'generating',
       content: undefined,
       messages: [],
-      metadata: {
-        messageCount: messages.length,
-        savedAt: new Date().toISOString(),
-      },
+      metadata: { messageCount: messages.length, savedAt: new Date().toISOString() },
     };
     onSaveChatOptimistic?.({ notebookId, note: placeholderNote });
-
     try {
-      const serializedMessages = messages.map(msg => ({
+      const serializedMessages = messages.map((msg) => ({
         ...msg,
         timestamp: msg.timestamp instanceof Date ? msg.timestamp.getTime() : msg.timestamp,
       }));
-
-      await saveChat({
-        notebookId,
-        messages: serializedMessages,
-        messageCount: messages.length,
-      });
+      await saveChat({ notebookId, messages: serializedMessages, messageCount: messages.length });
     } catch (error) {
       console.error('Failed to save chat:', error);
     } finally {
@@ -125,571 +115,280 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   };
 
-  const handleRefHover = (refId: number, messageId: string, event: React.MouseEvent) => {
-    handleRefEnter();
-    setHoveredRefId(refId);
-    setHoveredMessageId(messageId);
-    // Calculate if tooltip should appear above or below based on position
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
-    const containerRect = messagesContainerRef.current?.getBoundingClientRect();
-    
-    if (!containerRect) return;
+  // --- Tooltip / citation handlers ---
 
-    const spaceAbove = rect.top - containerRect.top;
-    const spaceBelow = containerRect.bottom - rect.bottom;
-    
-    const position = spaceAbove > spaceBelow ? 'top' : 'bottom';
-    setTooltipPosition(position);
-    
-    // Calculate tooltip position relative to messages container
-    const refCenterX = rect.left - containerRect.left + rect.width / 2;
-    const refCenterY = rect.top - containerRect.top;
-    
-    if (position === 'top') {
-      setTooltipStyle({
-        left: refCenterX,
-        top: refCenterY - 2,
-      });
-    } else {
-      setTooltipStyle({
-        left: refCenterX,
-        top: refCenterY + rect.height + 2,
-      });
-    }
-  };
-
-  const handleRefLeave = () => {
-    // Cancel any existing timeout
-    if (hideTooltipTimeoutRef.current) {
-      clearTimeout(hideTooltipTimeoutRef.current);
-    }
-    
-    // Set a delay before hiding - gives user time to move cursor to tooltip
-    hideTooltipTimeoutRef.current = setTimeout(() => {
-      if (!isTooltipHovered) {
-        setHoveredRefId(null);
-        setHoveredMessageId(null);
-      }
-    }, 150); // Reduced delay for better responsiveness
-  };
-
-  const handleRefEnter = () => {
-    // Cancel any pending hide when hovering back over badge
-    if (hideTooltipTimeoutRef.current) {
-      clearTimeout(hideTooltipTimeoutRef.current);
-    }
-  };
-
-  const handleRefClick = (refId: number, messageId: string, event: React.MouseEvent | React.TouchEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (hideTooltipTimeoutRef.current) {
-      clearTimeout(hideTooltipTimeoutRef.current);
-    }
-    // Toggle tooltip on mobile/touch devices
-    if (hoveredRefId === refId && hoveredMessageId === messageId) {
-      setHoveredRefId(null);
-      setHoveredMessageId(null);
-    } else {
-      handleRefHover(refId, messageId, event as React.MouseEvent);
-    }
-  };
-
-  const closeTooltip = () => {
-    if (hideTooltipTimeoutRef.current) {
-      clearTimeout(hideTooltipTimeoutRef.current);
-    }
+  const closeTooltip = useCallback(() => {
+    if (hideTooltipTimeoutRef.current) clearTimeout(hideTooltipTimeoutRef.current);
     setHoveredRefId(null);
     setHoveredMessageId(null);
     setIsTooltipHovered(false);
-  };
+  }, []);
 
-  // Close tooltip when clicking outside
+  const handleRefEnter = useCallback(() => {
+    if (hideTooltipTimeoutRef.current) clearTimeout(hideTooltipTimeoutRef.current);
+  }, []);
+
+  const handleRefLeave = useCallback(() => {
+    if (hideTooltipTimeoutRef.current) clearTimeout(hideTooltipTimeoutRef.current);
+    hideTooltipTimeoutRef.current = setTimeout(() => {
+      if (!isTooltipHovered) { setHoveredRefId(null); setHoveredMessageId(null); }
+    }, 150);
+  }, [isTooltipHovered]);
+
+  const handleRefHover = useCallback(
+    (refId: number, messageId: string, event: React.MouseEvent) => {
+      handleRefEnter();
+      setHoveredRefId(refId);
+      setHoveredMessageId(messageId);
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      const containerRect = messagesContainerRef.current?.getBoundingClientRect();
+      if (!containerRect) return;
+      const position = rect.top - containerRect.top > containerRect.bottom - rect.bottom ? 'top' : 'bottom';
+      setTooltipPosition(position);
+      const refCenterX = rect.left - containerRect.left + rect.width / 2;
+      const refCenterY = rect.top - containerRect.top;
+      setTooltipStyle(
+        position === 'top'
+          ? { left: refCenterX, top: refCenterY - 2 }
+          : { left: refCenterX, top: refCenterY + rect.height + 2 }
+      );
+    },
+    [handleRefEnter]
+  );
+
+  const handleRefClick = useCallback(
+    (refId: number, messageId: string, event: React.MouseEvent | React.TouchEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (hideTooltipTimeoutRef.current) clearTimeout(hideTooltipTimeoutRef.current);
+      if (hoveredRefId === refId && hoveredMessageId === messageId) {
+        setHoveredRefId(null);
+        setHoveredMessageId(null);
+      } else {
+        handleRefHover(refId, messageId, event as React.MouseEvent);
+      }
+    },
+    [hoveredRefId, hoveredMessageId, handleRefHover]
+  );
+
   useEffect(() => {
     if (!hoveredRefId) return;
-    
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      const target = event.target as Node;
-      if (tooltipRef.current?.contains(target)) return;
-      
-      // Check if clicking on a citation badge
-      const badge = (event.target as HTMLElement)?.closest('span[title^="Reference"]');
-      if (badge) return;
-      
+      if (tooltipRef.current?.contains(event.target as Node)) return;
+      if ((event.target as HTMLElement)?.closest('span[title^="Reference"]')) return;
       closeTooltip();
     };
-    
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('touchstart', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }, [hoveredRefId]);
+  }, [hoveredRefId, closeTooltip]);
 
-  // Handle sending a message
+  const refHandlers: RefHandlers = useMemo(
+    () => ({ onRefHover: handleRefHover, onRefLeave: handleRefLeave, onRefClick: handleRefClick }),
+    [handleRefHover, handleRefLeave, handleRefClick]
+  );
+
+  // --- Message handlers ---
+
+  const copyMessageAsMarkdown = useCallback(async (message: Message) => {
+    const stripRefs = (c: string) => {
+      const m = c.match(/\n?(?:References|Reference):\s*\n?[\d\s\.,\-:\–\—]*$/i);
+      return m ? c.substring(0, m.index).trim() : c;
+    };
+    try {
+      await navigator.clipboard.writeText(
+        message.role === 'assistant' ? stripRefs(message.content) : message.content
+      );
+      setCopiedMessageId(message.id);
+      setTimeout(() => setCopiedMessageId(null), 2000);
+    } catch { /* clipboard API not available */ }
+  }, []);
+
   const handleSendMessage = useCallback(async () => {
     const trimmed = inputMessage.trim();
     if (!trimmed || isSending || !notebookId || !onSendMessage) return;
-
     setIsSending(true);
     setInputMessage('');
-
-    // Add user message immediately to UI
     onSendMessage(trimmed);
-
-    try {
-      // The actual streaming is handled by the parent component via chatApi
-      // This component just triggers the send
-    } catch (error) {
-      console.error('Failed to send message:', error);
-    } finally {
-      setIsSending(false);
-    }
+    setIsSending(false);
   }, [inputMessage, isSending, notebookId, onSendMessage]);
 
-  // Handle textarea keydown (Enter to send)
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  }, [handleSendMessage]);
+  const handleSendChip = useCallback(
+    (text: string) => {
+      if (isSending || isLoading || !notebookId || !onSendMessage) return;
+      onSendMessage(text);
+    },
+    [isSending, isLoading, notebookId, onSendMessage]
+  );
 
-  // Auto-resize textarea
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = 'auto';
-      textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
-    }
-  }, [inputMessage]);
+  // --- Scroll to bottom ---
 
-  // Scroll to bottom when messages change using Virtuoso
   useEffect(() => {
     if (virtuosoRef.current && messages.length > 0) {
-      // Small delay to ensure Virtuoso has updated
       setTimeout(() => {
-        virtuosoRef.current?.scrollToIndex({
-          index: messages.length - 1,
-          align: 'end',
-          behavior: 'smooth',
-        });
+        virtuosoRef.current?.scrollToIndex({ index: messages.length - 1, align: 'end', behavior: 'smooth' });
       }, 100);
     }
   }, [messages.length]);
 
-  const copyMessageAsMarkdown = useCallback(async (message: Message) => {
-    const toCopy = message.role === 'assistant' ? stripReferencesSection(message.content) : message.content;
-    try {
-      await navigator.clipboard.writeText(toCopy);
-      setCopiedMessageId(message.id);
-      setTimeout(() => setCopiedMessageId(null), 2000);
-    } catch {
-      // clipboard API not available or denied
-    }
-  }, []);
+  // --- Tooltip position computation ---
 
-  // Strip "References:" section from message content (LLM sometimes adds it)
-  const stripReferencesSection = (content: string): string => {
-    // Match "References:" or "Reference:" followed by a list of references
-    // This handles formats like:
-    // - References:\n1. Title\n2. Title
-    // - References: 1 Title, 2 Title
-    const referencesPattern = /\n?(?:References|Reference):\s*\n?[\d\s\.,\-:\–\—]*$/i;
-    const match = content.match(referencesPattern);
-    if (match) {
-      return content.substring(0, match.index).trim();
-    }
-    return content;
-  };
+  const tooltipContent = useMemo(() => {
+    if (hoveredRefId === null || hoveredMessageId === null || !messagesContainerRef.current) return null;
+    const hoveredMessage = messages.find((msg) => msg.id === hoveredMessageId);
+    const refsArray = Array.isArray(hoveredMessage?.references) ? hoveredMessage.references : [];
+    const ref = refsArray.find((r) => Number(r.id) === hoveredRefId);
+    const containerRect = messagesContainerRef.current.getBoundingClientRect();
+    if (!ref || !containerRect) return null;
 
-  const renderMessageWithReferences = (messageId: string, content: string, references?: any[] | any) => {
-    // Strip any "References:" section that the LLM might have added
-    const cleanContent = stripReferencesSection(content);
+    const tooltipWidth = 384;
+    const rawX = (tooltipStyle.left || 0) + containerRect.left - tooltipWidth / 2;
+    const x = Math.max(containerRect.left + 16, Math.min(rawX, containerRect.right - tooltipWidth - 16));
+    const y =
+      tooltipPosition === 'top'
+        ? containerRect.top + (tooltipStyle.top || 0) - 256 - 2
+        : containerRect.top + (tooltipStyle.top || 0);
 
-    // Sanitize markdown content to prevent XSS
-    const sanitizedContent = sanitizeMarkdown(cleanContent);
+    return { ref, x, y };
+  }, [hoveredRefId, hoveredMessageId, messages, tooltipStyle, tooltipPosition]);
 
-    // Handle references that might be an object instead of array
-    Array.isArray(references) ? references : [];
-
-    // Convert citation markers [1] to inline code markers `CITE:1` only outside math (so LaTeX like [1, 0] is unchanged)
-    const processedContent = replaceCitationMarkersOutsideMath(sanitizedContent);
-
-    return (
-      <div className="prose font-serif text-base leading-relaxed space-y-2 max-w-none">
-        <Suspense fallback={<div className="animate-pulse h-4 bg-secondary/30 rounded w-full" />}>
-          <MarkdownRenderer
-            components={{
-              img: () => null,
-              a: ({ children }) => <span className="text-foreground">{children}</span>,
-              video: () => null,
-              audio: () => null,
-              iframe: () => null,
-              table: ({ children }) => React.createElement('table', { className: 'w-full border-collapse border border-border rounded-lg overflow-hidden' }, children),
-              thead: ({ children }) => React.createElement('thead', { className: 'bg-secondary/50' }, children),
-              tbody: ({ children }) => React.createElement('tbody', null, children),
-              tr: ({ children }) => React.createElement('tr', { className: 'border-b border-border' }, children),
-              th: ({ children }) => React.createElement('th', { className: 'px-4 py-2 text-left font-semibold text-foreground border-r border-border last:border-r-0' }, children),
-              td: ({ children }) => React.createElement('td', { className: 'px-4 py-2 text-foreground border-r border-border last:border-r-0' }, children),
-              p: ({ children }) => {
-                return <p className="text-base leading-relaxed">{children}</p>;
-              },
-              code: ({ children, node }: any) => {
-                // Check if this is a citation marker
-                const text = String(children);
-                // Code blocks are wrapped in pre, inline code is not
-                const isInline = !node?.position || (node as any).data?.meta === undefined;
-                
-                if (isInline && text.startsWith('CITE:')) {
-                  const refId = parseInt(text.slice(5));
-                  return (
-                    <span
-                      onMouseEnter={(e) => handleRefHover(refId, messageId, e)}
-                      onMouseLeave={handleRefLeave}
-                      onClick={(e) => handleRefClick(refId, messageId, e)}
-                      onTouchStart={(e) => handleRefClick(refId, messageId, e)}
-                      className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground text-[10px] font-bold cursor-pointer hover:bg-primary/90 active:bg-primary/80 transition-colors mx-1 align-middle relative touch-manipulation"
-                      title={`Reference ${refId}`}
-                      style={{ verticalAlign: 'middle' }}
-                    >
-                      {refId}
-                    </span>
-                  );
-                }
-                // Regular inline code
-                return <code className="bg-secondary/50 px-1.5 py-0.5 rounded text-sm">{children}</code>;
-              },
-            }}
-          >
-            {processedContent}
-          </MarkdownRenderer>
-        </Suspense>
-      </div>
-    );
-  };
-
-  // Status icon mapping for "Thinking" states
-  const getStatusIcon = (status?: string) => {
-    switch (status) {
-      case 'searching':
-        return <Search className="w-4 h-4 animate-pulse" />;
-      case 'reading':
-        return <FileText className="w-4 h-4 animate-pulse" />;
-      case 'thinking':
-        return <Brain className="w-4 h-4 animate-pulse" />;
-      case 'generating':
-        return <Loader2 className="w-4 h-4 animate-spin" />;
-      default:
-        return null;
-    }
-  };
-
-  // Status message mapping
-  const getStatusMessage = (status?: string) => {
-    switch (status) {
-      case 'searching':
-        return 'Searching sources...';
-      case 'reading':
-        return 'Reading sources...';
-      case 'thinking':
-        return 'Thinking...';
-      case 'generating':
-        return 'Generating response...';
-      default:
-        return null;
-    }
-  };
-
-  // Memoized MessageBubble component for performance
-  const MessageBubble = React.memo<{
-    message: Message;
-    onRefHover: (refId: number, messageId: string, event: React.MouseEvent) => void;
-    onRefLeave: () => void;
-    onCopyMessage: (message: Message) => void;
-    copiedMessageId: string | null;
-  }>(({ message, onRefHover: _onRefHover, onRefLeave: _onRefLeave, onCopyMessage, copiedMessageId }) => {
-    const isUser = message.role === 'user';
-    const isCopied = copiedMessageId === message.id;
-
-    // Extensible action list: add new entries here to show more message actions
-    const messageActions = [
-      {
-        id: 'copy',
-        label: isCopied ? 'Copied' : 'Copy',
-        icon: isCopied ? Check : Copy,
-        onClick: () => onCopyMessage(message),
-        className: isCopied ? 'text-green-600' : '',
-      },
-      // Future: { id: 'regenerate', label: 'Regenerate', icon: RefreshCw, onClick: () => {} },
-      // Future: { id: 'thumbs-up', label: 'Good response', icon: ThumbsUp, onClick: () => {} },
-    ];
-
-    const ActionBar = () => (
-      <div
-        className="flex items-center rounded-full border border-border/80 bg-card/90 shadow-sm backdrop-blur-sm overflow-hidden opacity-0 group-hover/message:opacity-100 transition-opacity duration-200"
-        role="toolbar"
-        aria-label="Message actions"
-      >
-        {messageActions.map(({ id, label, icon: Icon, onClick, className = '' }) => (
-          <button
-            key={id}
-            type="button"
-            onClick={onClick}
-            title={label}
-            aria-label={label}
-            className={`p-2 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors touch-manipulation first:pl-2.5 last:pr-2.5 ${className}`}
-          >
-            <Icon className="w-4 h-4" aria-hidden />
-          </button>
-        ))}
-      </div>
-    );
-
-    return (
-      <div className={`group/message flex flex-col ${isUser ? 'items-end' : 'items-start'} gap-1`} data-message-id={message.id}>
-        {isUser ? (
-          <div className="flex flex-row items-start gap-2 max-w-[95%]">
-            <div className="shrink-0 pt-4">
-              <ActionBar />
-            </div>
-            <div className="p-4 rounded-xl font-serif text-lg leading-relaxed bg-primary/10 text-foreground shadow-sm">
-              {renderMessageWithReferences(message.id, message.content, message.references)}
-            </div>
-          </div>
-        ) : (
-          <>
-            {/* Status indicator for assistant messages */}
-            {message.status && (
-              <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                {getStatusIcon(message.status)}
-                <span className="animate-pulse">{getStatusMessage(message.status)}</span>
-              </div>
-            )}
-            <div className="w-full max-w-4xl font-serif text-lg leading-relaxed text-foreground">
-              {renderMessageWithReferences(message.id, message.content, message.references)}
-              <div className="flex justify-start mt-3">
-                <ActionBar />
-              </div>
-            </div>
-          </>
-        )}
-      </div>
-    );
-  }, (prev, next) => {
-    // Only re-render if content, status, references, or copy state change
-    return (
-      prev.message.id === next.message.id &&
-      prev.message.content === next.message.content &&
-      prev.message.status === next.message.status &&
-      prev.message.references === next.message.references &&
-      prev.copiedMessageId === next.copiedMessageId
-    );
-  });
-
-  // Memoize the messages array to prevent unnecessary re-renders
   const memoizedMessages = useMemo(() => messages, [messages]);
 
   return (
-    <><div className="flex-1 flex flex-col h-full bg-background relative overflow-hidden">
-      
-      {/* Header */}
-      <div className="hidden md:flex items-center justify-between p-4 border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-10 h-14">
-        <div className="flex items-center gap-2 text-foreground">
-          <MessageCircle className="w-4 h-4" />
-          <span className="font-sans font-bold text-sm tracking-wide uppercase">Chat</span>
-        </div>
-        
-        {/* Right Side Controls */}
-        <div className="flex items-center gap-2">
-          {/* Panel Toggle Buttons - shown when panels are closed */}
-          {!isLeftOpen && (
-            <button 
-              onClick={toggleLeft}
-              className="p-2 bg-card border border-border rounded-lg shadow-sm hover:bg-accent text-foreground transition-colors shrink-0"
-              title="Open Sources"
-            >
-              <PanelLeftOpen className="w-4 h-4" />
-            </button>
-          )}
-          {!isRightOpen && (
-            <button 
-              onClick={toggleRight}
-              className="p-2 bg-card border border-border rounded-lg shadow-sm hover:bg-accent text-foreground transition-colors shrink-0"
-              title="Open Studio"
-            >
-              <PanelRightOpen className="w-4 h-4" />
-            </button>
-          )}
+    <>
+      <div className="flex-1 flex flex-col h-full bg-background relative overflow-hidden">
 
-          {/* Chat actions kebab menu */}
-          <DropdownMenu
-            align="right"
-            trigger={
+        {/* Header */}
+        <div className="hidden md:flex items-center justify-between p-4 border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-10 h-14">
+          <div className="flex items-center gap-2 text-foreground">
+            <MessageCircle className="w-4 h-4" />
+            <span className="font-sans font-bold text-sm tracking-wide uppercase">Chat</span>
+          </div>
+          <div className="flex items-center gap-2">
+            {!isLeftOpen && (
               <button
+                onClick={toggleLeft}
                 className="p-2 bg-card border border-border rounded-lg shadow-sm hover:bg-accent text-foreground transition-colors shrink-0"
-                title="Chat options"
-                type="button"
+                title="Open Sources"
               >
-                <MoreVertical className="w-4 h-4" />
+                <PanelLeftOpen className="w-4 h-4" />
               </button>
-            }
-          >
-            <div className="py-1">
+            )}
+            {!isRightOpen && (
               <button
-                onClick={handleDeleteHistory}
-                className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
-                role="menuitem"
+                onClick={toggleRight}
+                className="p-2 bg-card border border-border rounded-lg shadow-sm hover:bg-accent text-foreground transition-colors shrink-0"
+                title="Open Studio"
               >
-                <RefreshCw className="w-4 h-4 text-muted-foreground shrink-0" />
-                <span>Refresh chat</span>
+                <PanelRightOpen className="w-4 h-4" />
               </button>
-              <button
-                onClick={handleExportChat}
-                className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
-                role="menuitem"
-              >
-                <Download className="w-4 h-4 text-muted-foreground shrink-0" />
-                <span>Export chat</span>
-              </button>
-              <button
-                onClick={handleSaveToNote}
-                className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
-                role="menuitem"
-              >
-                <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
-                <span>Save to note</span>
-              </button>
-            </div>
-          </DropdownMenu>
+            )}
+            <DropdownMenu
+              align="right"
+              trigger={
+                <button
+                  className="p-2 bg-card border border-border rounded-lg shadow-sm hover:bg-accent text-foreground transition-colors shrink-0"
+                  title="Chat options"
+                  type="button"
+                >
+                  <MoreVertical className="w-4 h-4" />
+                </button>
+              }
+            >
+              <div className="py-1">
+                <button
+                  onClick={handleDeleteHistory}
+                  className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
+                  role="menuitem"
+                >
+                  <RefreshCw className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span>Refresh chat</span>
+                </button>
+                <button
+                  onClick={handleExportChat}
+                  className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
+                  role="menuitem"
+                >
+                  <Download className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span>Export chat</span>
+                </button>
+                <button
+                  onClick={handleSaveToNote}
+                  className="w-full px-4 py-2.5 text-left hover:bg-accent transition-colors flex items-center gap-3 text-sm font-sans"
+                  role="menuitem"
+                >
+                  <FileText className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span>Save to note</span>
+                </button>
+              </div>
+            </DropdownMenu>
+          </div>
         </div>
-      </div>
 
-      {/* Messages Area - Virtualized */}
-      <div
-        ref={messagesContainerRef}
-        className="flex-1 overflow-hidden relative"
-      >
-        <Virtuoso
-          ref={virtuosoRef}
-          style={{ height: '100%' }}
-          data={memoizedMessages}
-          itemContent={(_index, message) => (
-            <div className="px-3 py-3 sm:px-4 md:px-6">
-              <MessageBubble
-                key={message.id}
-                message={message}
-                onRefHover={handleRefHover}
-                onRefLeave={handleRefLeave}
-                onCopyMessage={copyMessageAsMarkdown}
-                copiedMessageId={copiedMessageId}
-              />
-            </div>
+        {/* Messages Area */}
+        <div ref={messagesContainerRef} className="flex-1 overflow-hidden relative">
+          {messages.length === 0 ? (
+            <ChatEmptyState onSendMessage={handleSendChip} disabled={isSending || isLoading} />
+          ) : (
+            <Virtuoso
+              ref={virtuosoRef}
+              style={{ height: '100%' }}
+              data={memoizedMessages}
+              itemContent={(_index, message) => (
+                <div className="px-3 py-3 sm:px-4 md:px-6">
+                  <MessageBubble
+                    message={message}
+                    refHandlers={refHandlers}
+                    onCopyMessage={copyMessageAsMarkdown}
+                    copiedMessageId={copiedMessageId}
+                    onSetFeedback={onSetFeedback}
+                    onSendFollowUp={handleSendChip}
+                  />
+                </div>
+              )}
+              components={{ Footer: () => <div className="h-56" /> }}
+              defaultItemHeight={150}
+              increaseViewportBy={{ top: 200, bottom: 400 }}
+            />
           )}
-          components={{
-            Footer: () => <div className="h-56" />,
-          }}
-          defaultItemHeight={150}
-          increaseViewportBy={{ top: 200, bottom: 400 }}
-        />
 
-        {/* Floating Tooltip */}
-        {hoveredRefId !== null && hoveredMessageId !== null && messagesContainerRef.current && (() => {
-          // Find the message being hovered
-          const hoveredMessage = messages.find(msg => msg.id === hoveredMessageId);
-
-          // Normalize references to array
-          const refsArray = Array.isArray(hoveredMessage?.references) ? hoveredMessage.references : [];
-
-          // Only look for references within that specific message
-          const ref = refsArray.find(r => Number(r.id) === hoveredRefId);
-          const containerRect = messagesContainerRef.current?.getBoundingClientRect();
-          
-          if (!ref || !containerRect) return null;
-
-          const tooltipX = (tooltipStyle.left || 0) + containerRect.left;
-          const tooltipWidth = 384; // w-96
-          
-          // Clamp tooltip X position to stay within viewport
-          let adjustedX = tooltipX - tooltipWidth / 2;
-          const minX = containerRect.left + 16; // padding
-          const maxX = containerRect.right - tooltipWidth - 16;
-          
-          if (adjustedX < minX) adjustedX = minX;
-          if (adjustedX > maxX) adjustedX = maxX;
-          
-          const tooltipY = tooltipPosition === 'top' 
-            ? containerRect.top + (tooltipStyle.top || 0) - 256 - 2
-            : containerRect.top + (tooltipStyle.top || 0);
-          
-          return (
-            <div
-              ref={tooltipRef}
-              className="fixed z-50"
-              style={{
-                left: `${adjustedX}px`,
-                top: `${tooltipY}px`,
-                pointerEvents: 'auto',
-              }}
+          {/* Floating Reference Tooltip */}
+          {tooltipContent && (
+            <ReferenceTooltip
+              hoveredRefId={hoveredRefId!}
+              tooltipRef={tooltipRef}
+              reference={tooltipContent.ref}
+              position={{ x: tooltipContent.x, y: tooltipContent.y }}
               onMouseEnter={() => {
                 setIsTooltipHovered(true);
-                // Clear any pending hide timeout when hovering over tooltip
-                if (hideTooltipTimeoutRef.current) {
-                  clearTimeout(hideTooltipTimeoutRef.current);
-                }
+                if (hideTooltipTimeoutRef.current) clearTimeout(hideTooltipTimeoutRef.current);
               }}
               onMouseLeave={() => {
                 setIsTooltipHovered(false);
                 hideTooltipTimeoutRef.current = setTimeout(() => {
-                  if (!isTooltipHovered) {
-                    setHoveredRefId(null);
-                    setHoveredMessageId(null);
-                  }
+                  if (!isTooltipHovered) { setHoveredRefId(null); setHoveredMessageId(null); }
                 }, 100);
               }}
-            >
-              <div className="bg-popover border border-border rounded-2xl shadow-xl p-5 w-96 max-h-64 overflow-y-auto text-sm animate-in fade-in zoom-in-95 duration-200 flex flex-col relative">
-                <p className="text-[10px] uppercase tracking-widest font-mono text-muted-foreground mb-3 font-bold shrink-0">
-                  Reference {hoveredRefId} • {ref.sourceTitle}
-                </p>
-                <p className="text-popover-foreground whitespace-pre-wrap text-sm leading-relaxed">
-                  {ref.content}
-                </p>
-              </div>
-            </div>
-          );
-        })()}
-      </div>
-
-      {/* Input Area */}
-      <div className="absolute bottom-8 left-0 right-0 px-4 flex justify-center z-20">
-        <div className="w-full max-w-3xl xl:max-w-4xl 2xl:max-w-5xl bg-card border-2 border-border shadow-lg rounded-2xl py-1.5 px-2 flex flex-col gap-1 relative">
-
-           <textarea
-             ref={textareaRef}
-             placeholder="Ask a question about your sources..."
-             className="w-full bg-transparent border-none py-2 px-3 resize-none outline-none text-foreground placeholder:text-muted-foreground/70 min-h-[44px] max-h-[160px] font-serif text-lg"
-             rows={1}
-             value={inputMessage}
-             onChange={(e) => setInputMessage(e.target.value)}
-             onKeyDown={handleKeyDown}
-             disabled={isSending || isLoading}
-           />
-
-           <div className="flex justify-end items-center px-1.5 pb-0.5">
-             <button
-               onClick={handleSendMessage}
-               disabled={!inputMessage.trim() || isSending || isLoading || !notebookId}
-               className="p-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-all shadow-md active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
-               title={inputMessage.trim() ? 'Send message (Enter)' : 'Type a message to send'}
-             >
-               {isSending || isLoading ? <Loader2 className="w-5 h-5 animate-spin" /> : <ArrowUp className="w-5 h-5" />}
-             </button>
-           </div>
+            />
+          )}
         </div>
-      </div>
+
+        {/* Input Area */}
+        <div className="absolute bottom-8 left-0 right-0 px-4 flex justify-center z-20">
+          <ChatInput
+            value={inputMessage}
+            onChange={setInputMessage}
+            onSend={handleSendMessage}
+            disabled={isSending || isLoading}
+            notebookId={notebookId}
+          />
+        </div>
+
       </div>
       <ConfirmDialogComponent />
-    </>);
+    </>
+  );
 };

--- a/apps/web/src/features/chat/components/MessageBubble.tsx
+++ b/apps/web/src/features/chat/components/MessageBubble.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { Check, Copy, ThumbsUp, ThumbsDown, Search } from 'lucide-react';
+import { Message } from '@/shared/types/index';
+import { renderMessageWithReferences, RefHandlers } from '../utils/messageRendering';
+import { getStatusIcon, getStatusMessage } from '../utils/messageStatus';
+
+interface MessageBubbleProps {
+  message: Message;
+  refHandlers: RefHandlers;
+  onCopyMessage: (message: Message) => void;
+  copiedMessageId: string | null;
+  onSetFeedback?: (messageId: string, feedback: 'up' | 'down' | null) => void;
+  onSendFollowUp?: (text: string) => void;
+}
+
+export const MessageBubble = React.memo<MessageBubbleProps>(
+  ({ message, refHandlers, onCopyMessage, copiedMessageId, onSetFeedback, onSendFollowUp }) => {
+    const isUser = message.role === 'user';
+    const isCopied = copiedMessageId === message.id;
+
+    const messageActions: Array<{
+      id: string;
+      label: string;
+      icon: React.ElementType;
+      onClick: () => void;
+      className?: string;
+    }> = [
+      {
+        id: 'copy',
+        label: isCopied ? 'Copied' : 'Copy',
+        icon: isCopied ? Check : Copy,
+        onClick: () => onCopyMessage(message),
+        className: isCopied ? 'text-green-600' : '',
+      },
+    ];
+
+    if (!isUser && onSetFeedback) {
+      messageActions.push(
+        {
+          id: 'thumbs-up',
+          label: 'Good response',
+          icon: ThumbsUp,
+          onClick: () => onSetFeedback(message.id, message.feedback === 'up' ? null : 'up'),
+          className: message.feedback === 'up' ? 'text-green-600 fill-green-600' : '',
+        },
+        {
+          id: 'thumbs-down',
+          label: 'Bad response',
+          icon: ThumbsDown,
+          onClick: () => onSetFeedback(message.id, message.feedback === 'down' ? null : 'down'),
+          className: message.feedback === 'down' ? 'text-red-500 fill-red-500' : '',
+        }
+      );
+    }
+
+    const ActionBar = () => (
+      <div
+        className="flex items-center rounded-full border border-border/80 bg-card/90 shadow-sm backdrop-blur-sm overflow-hidden opacity-0 group-hover/message:opacity-100 transition-opacity duration-200"
+        role="toolbar"
+        aria-label="Message actions"
+      >
+        {messageActions.map(({ id, label, icon: Icon, onClick, className = '' }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={onClick}
+            title={label}
+            aria-label={label}
+            className={`p-2 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors touch-manipulation first:pl-2.5 last:pr-2.5 ${className}`}
+          >
+            <Icon className="w-4 h-4" aria-hidden />
+          </button>
+        ))}
+      </div>
+    );
+
+    const ToolCallTrace = () => {
+      if (!message.toolCalls || message.toolCalls.length === 0) return null;
+      return (
+        <div className="flex flex-col gap-1 mb-2">
+          {message.toolCalls.map((tc, i) => (
+            <div key={i} className="flex items-center gap-2 text-xs text-muted-foreground font-mono">
+              {tc.status === 'searching' ? (
+                <Search className="w-3 h-3 animate-pulse shrink-0" />
+              ) : (
+                <Check className="w-3 h-3 text-green-500 shrink-0" />
+              )}
+              <span>
+                {tc.status === 'searching'
+                  ? `Searching for "${tc.query}"...`
+                  : `Found ${tc.resultCount ?? 0} passages`}
+              </span>
+            </div>
+          ))}
+        </div>
+      );
+    };
+
+    const FollowUpChips = () => {
+      if (!message.followUps || message.followUps.length === 0 || !onSendFollowUp) return null;
+      return (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {message.followUps.map((q, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onSendFollowUp(q)}
+              className="px-3 py-1.5 rounded-full border border-border bg-card hover:bg-accent text-sm text-foreground transition-colors text-left font-sans"
+            >
+              {q}
+            </button>
+          ))}
+        </div>
+      );
+    };
+
+    return (
+      <div
+        className={`group/message flex flex-col ${isUser ? 'items-end' : 'items-start'} gap-1`}
+        data-message-id={message.id}
+      >
+        {isUser ? (
+          <div className="flex flex-row items-start gap-2 max-w-[95%]">
+            <div className="shrink-0 pt-4">
+              <ActionBar />
+            </div>
+            <div className="p-4 rounded-xl font-serif text-lg leading-relaxed bg-primary/10 text-foreground shadow-sm">
+              {renderMessageWithReferences(message.id, message.content, message.references, refHandlers)}
+            </div>
+          </div>
+        ) : (
+          <>
+            {message.status && (
+              <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
+                {getStatusIcon(message.status)}
+                <span className="animate-pulse">{getStatusMessage(message.status)}</span>
+              </div>
+            )}
+            <ToolCallTrace />
+            <div className="w-full max-w-4xl font-serif text-lg leading-relaxed text-foreground">
+              {message.content ? (
+                renderMessageWithReferences(message.id, message.content, message.references, refHandlers)
+              ) : (
+                <div className="flex items-center gap-1.5 py-3">
+                  <span className="w-2 h-2 rounded-full bg-foreground/30 animate-bounce" style={{ animationDelay: '0ms', animationDuration: '1.2s' }} />
+                  <span className="w-2 h-2 rounded-full bg-foreground/30 animate-bounce" style={{ animationDelay: '200ms', animationDuration: '1.2s' }} />
+                  <span className="w-2 h-2 rounded-full bg-foreground/30 animate-bounce" style={{ animationDelay: '400ms', animationDuration: '1.2s' }} />
+                </div>
+              )}
+              <div className="flex justify-start mt-3">
+                <ActionBar />
+              </div>
+              <FollowUpChips />
+            </div>
+          </>
+        )}
+      </div>
+    );
+  },
+  (prev, next) =>
+    prev.message.id === next.message.id &&
+    prev.message.content === next.message.content &&
+    prev.message.status === next.message.status &&
+    prev.message.references === next.message.references &&
+    prev.message.feedback === next.message.feedback &&
+    prev.message.followUps === next.message.followUps &&
+    prev.message.toolCalls === next.message.toolCalls &&
+    prev.copiedMessageId === next.copiedMessageId
+);
+
+MessageBubble.displayName = 'MessageBubble';

--- a/apps/web/src/features/chat/components/ReferenceTooltip.tsx
+++ b/apps/web/src/features/chat/components/ReferenceTooltip.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ReferenceChunk } from '@/shared/types/index';
+
+interface ReferenceTooltipProps {
+  hoveredRefId: number;
+  tooltipRef: React.RefObject<HTMLDivElement | null>;
+  reference: ReferenceChunk;
+  position: { x: number; y: number };
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+export const ReferenceTooltip: React.FC<ReferenceTooltipProps> = ({
+  hoveredRefId,
+  tooltipRef,
+  reference,
+  position,
+  onMouseEnter,
+  onMouseLeave,
+}) => (
+  <div
+    ref={tooltipRef}
+    className="fixed z-50"
+    style={{ left: `${position.x}px`, top: `${position.y}px`, pointerEvents: 'auto' }}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+  >
+    <div className="bg-popover border border-border rounded-2xl shadow-xl p-5 w-96 max-h-64 overflow-y-auto text-sm animate-in fade-in zoom-in-95 duration-200 flex flex-col relative">
+      <p className="text-[10px] uppercase tracking-widest font-mono text-muted-foreground mb-3 font-bold shrink-0">
+        Reference {hoveredRefId} • {reference.sourceTitle}
+      </p>
+      <p className="text-popover-foreground whitespace-pre-wrap text-sm leading-relaxed">
+        {reference.content}
+      </p>
+    </div>
+  </div>
+);

--- a/apps/web/src/features/chat/services/chatApi.ts
+++ b/apps/web/src/features/chat/services/chatApi.ts
@@ -28,6 +28,9 @@ export interface ParsedStreamData {
   references?: ReferenceChunk[];
   status?: { status: string; message: string };
   groundingCheck?: { passed: boolean; issues: string[]; message: string };
+  toolCall?: { tool: string; query: string; status: 'searching' | 'done'; resultCount?: number };
+  followUps?: string[];
+  clarification?: { question: string };
   error?: { message: string; type?: string };
   isDone: boolean;
 }
@@ -71,6 +74,9 @@ export interface SendMessageCallbacks {
   onToken: (token: string) => void;
   onReferences: (references: ReferenceChunk[]) => void;
   onStatus?: (status: string, message?: string) => void;
+  onToolCall?: (toolCall: { tool: string; query: string; status: 'searching' | 'done'; resultCount?: number }) => void;
+  onFollowUps?: (questions: string[]) => void;
+  onClarification?: (question: string) => void;
   onComplete: () => void;
   onError: (error: string | ChatError) => void;
 }
@@ -110,6 +116,24 @@ export function parseStreamBody(body: string): ParsedStreamData {
       try {
         const jsonStr = line.slice('__GROUNDING:'.length);
         result.groundingCheck = JSON.parse(jsonStr);
+      } catch {
+        // Ignore parse errors
+      }
+    } else if (line.startsWith('__TOOL_CALL:')) {
+      try {
+        result.toolCall = JSON.parse(line.slice('__TOOL_CALL:'.length));
+      } catch {
+        // Ignore parse errors
+      }
+    } else if (line.startsWith('__FOLLOWUPS:')) {
+      try {
+        result.followUps = JSON.parse(line.slice('__FOLLOWUPS:'.length));
+      } catch {
+        // Ignore parse errors
+      }
+    } else if (line.startsWith('__CLARIFICATION:')) {
+      try {
+        result.clarification = JSON.parse(line.slice('__CLARIFICATION:'.length));
       } catch {
         // Ignore parse errors
       }
@@ -299,8 +323,16 @@ export function useSendMessage() {
         if (parsed.status) {
           callbacks.onStatus?.(parsed.status.status, parsed.status.message);
         }
+        if (parsed.toolCall) {
+          callbacks.onToolCall?.(parsed.toolCall);
+        }
+        if (parsed.followUps) {
+          callbacks.onFollowUps?.(parsed.followUps);
+        }
+        if (parsed.clarification) {
+          callbacks.onClarification?.(parsed.clarification.question);
+        }
         if (parsed.groundingCheck) {
-          // You can add a callback for grounding checks if needed
           console.log('[Chat] Grounding check:', parsed.groundingCheck);
         }
         if (parsed.error) {
@@ -327,4 +359,17 @@ export function useSendMessage() {
   }, [sendMessageMutation, isAuthenticated, authToken]);
 
   return sendMessage;
+}
+
+/**
+ * Set thumbs up/down feedback on an assistant message.
+ * Pass null to remove existing feedback.
+ */
+export function useSetMessageFeedback() {
+  const setFeedback = useMutation(api.chat.messages.setMessageFeedback);
+  return useCallback(
+    (messageId: string, feedback: 'up' | 'down' | null) =>
+      setFeedback({ messageId: messageId as Id<'messages'>, feedback }),
+    [setFeedback]
+  );
 }

--- a/apps/web/src/features/chat/utils/messageRendering.tsx
+++ b/apps/web/src/features/chat/utils/messageRendering.tsx
@@ -1,0 +1,85 @@
+import React, { Suspense, lazy } from 'react';
+import { sanitizeMarkdown } from '@/shared/utils';
+import { replaceCitationMarkersOutsideMath } from './citationMarkers';
+
+const MarkdownRenderer = lazy(() =>
+  import('@/shared/components/MarkdownRenderer').then((m) => ({ default: m.default }))
+);
+
+export function stripReferencesSection(content: string): string {
+  const referencesPattern = /\n?(?:References|Reference):\s*\n?[\d\s\.,\-:\–\—]*$/i;
+  const match = content.match(referencesPattern);
+  if (match) {
+    return content.substring(0, match.index).trim();
+  }
+  return content;
+}
+
+export interface RefHandlers {
+  onRefHover: (refId: number, messageId: string, event: React.MouseEvent) => void;
+  onRefLeave: () => void;
+  onRefClick: (refId: number, messageId: string, event: React.MouseEvent | React.TouchEvent) => void;
+}
+
+export function renderMessageWithReferences(
+  messageId: string,
+  content: string,
+  _references: any[] | undefined,
+  handlers: RefHandlers
+): React.ReactNode {
+  const cleanContent = stripReferencesSection(content);
+  const sanitizedContent = sanitizeMarkdown(cleanContent);
+  const processedContent = replaceCitationMarkersOutsideMath(sanitizedContent);
+
+  return (
+    <div className="prose font-serif text-base leading-relaxed space-y-2 max-w-none">
+      <Suspense fallback={<div className="animate-pulse h-4 bg-secondary/30 rounded w-full" />}>
+        <MarkdownRenderer
+          components={{
+            img: () => null,
+            a: ({ children }) => <span className="text-foreground">{children}</span>,
+            video: () => null,
+            audio: () => null,
+            iframe: () => null,
+            table: ({ children }) =>
+              React.createElement('table', { className: 'w-full border-collapse border border-border rounded-lg overflow-hidden' }, children),
+            thead: ({ children }) =>
+              React.createElement('thead', { className: 'bg-secondary/50' }, children),
+            tbody: ({ children }) =>
+              React.createElement('tbody', null, children),
+            tr: ({ children }) =>
+              React.createElement('tr', { className: 'border-b border-border' }, children),
+            th: ({ children }) =>
+              React.createElement('th', { className: 'px-4 py-2 text-left font-semibold text-foreground border-r border-border last:border-r-0' }, children),
+            td: ({ children }) =>
+              React.createElement('td', { className: 'px-4 py-2 text-foreground border-r border-border last:border-r-0' }, children),
+            p: ({ children }) => <p className="text-base leading-relaxed">{children}</p>,
+            code: ({ children, node }: any) => {
+              const text = String(children);
+              const isInline = !node?.position || (node as any).data?.meta === undefined;
+              if (isInline && text.startsWith('CITE:')) {
+                const refId = parseInt(text.slice(5));
+                return (
+                  <span
+                    onMouseEnter={(e) => handlers.onRefHover(refId, messageId, e)}
+                    onMouseLeave={handlers.onRefLeave}
+                    onClick={(e) => handlers.onRefClick(refId, messageId, e)}
+                    onTouchStart={(e) => handlers.onRefClick(refId, messageId, e)}
+                    className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-primary-foreground text-[10px] font-bold cursor-pointer hover:bg-primary/90 active:bg-primary/80 transition-colors mx-1 align-middle relative touch-manipulation"
+                    title={`Reference ${refId}`}
+                    style={{ verticalAlign: 'middle' }}
+                  >
+                    {refId}
+                  </span>
+                );
+              }
+              return <code className="bg-secondary/50 px-1.5 py-0.5 rounded text-sm">{children}</code>;
+            },
+          }}
+        >
+          {processedContent}
+        </MarkdownRenderer>
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/features/chat/utils/messageStatus.tsx
+++ b/apps/web/src/features/chat/utils/messageStatus.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Search, FileText, Brain, Loader2 } from 'lucide-react';
+
+export function getStatusIcon(status?: string): React.ReactNode {
+  switch (status) {
+    case 'searching': return <Search className="w-4 h-4 animate-pulse" />;
+    case 'reading': return <FileText className="w-4 h-4 animate-pulse" />;
+    case 'thinking': return <Brain className="w-4 h-4 animate-pulse" />;
+    case 'generating': return <Loader2 className="w-4 h-4 animate-spin" />;
+    default: return null;
+  }
+}
+
+export function getStatusMessage(status?: string): string | null {
+  switch (status) {
+    case 'searching': return 'Searching sources...';
+    case 'reading': return 'Reading sources...';
+    case 'thinking': return 'Thinking...';
+    case 'generating': return 'Generating response...';
+    default: return null;
+  }
+}

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -21,6 +21,13 @@ export interface ReferenceChunk {
   similarity?: number;
 }
 
+export interface MessageToolCall {
+  tool: string;
+  query: string;
+  status: 'searching' | 'done';
+  resultCount?: number;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -29,6 +36,9 @@ export interface Message {
   references?: ReferenceChunk[];
   timestamp: Date;
   status?: 'searching' | 'reading' | 'thinking' | 'generating';
+  feedback?: 'up' | 'down';
+  followUps?: string[];
+  toolCalls?: MessageToolCall[];
 }
 
 export interface StudioTool {

--- a/convex/_agents/ChatAgent.ts
+++ b/convex/_agents/ChatAgent.ts
@@ -2,30 +2,29 @@
 /**
  * Chat Agent Service
  *
- * Orchestrates chat responses with strict RAG (Retrieval-Augmented Generation)
- * using extracted modules for vector search, grounding validation, and LLM generation.
- *
- * This refactored version uses composition patterns with dedicated modules:
- * - VectorSearchHandler: Hybrid search with reranking
- * - ChatLLMWrapper: Structured output generation
- * - validateGrounding: Grounding validation
+ * Orchestrates chat responses using a constrained tool-calling loop:
+ * 1. LLM decides what to search for (search_documents / ask_clarification tools)
+ * 2. HyDE embedding improves retrieval quality
+ * 3. Structured generation with citations
+ * 4. Grounding validation with one retry on failure
+ * 5. Follow-up question generation
  */
 
 import { env } from '../_lib/env';
+import { ChatTogetherAI } from '@langchain/community/chat_models/togetherai';
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
 
-// Import extracted modules
 import { VectorSearchHandler } from './chat/vector_search.js';
 import { ChatLLMWrapper, type ChatResponse } from './chat/llm_wrapper.js';
-import { validateGrounding, isArtifactContent, validateSemanticGrounding } from './chat/grounding_validator.js';
+import { validateGrounding, validateSemanticGrounding } from './chat/grounding_validator.js';
 import { EmbeddingService } from '../_services/processing/EmbeddingServiceClient';
+import type { ReferenceChunk } from '../storage/ChatHistoryService';
 
 // ============================================================
 // Types
 // ============================================================
 
-/**
- * Context for chat agent execution.
- */
 export interface ChatAgentContext {
   userId: string;
   noteId: string;
@@ -33,52 +32,83 @@ export interface ChatAgentContext {
   documentIds?: string[];
 }
 
-/**
- * Stream chunk for streaming responses.
- */
 export interface StreamChunk {
-  type: 'token' | 'references' | 'done' | 'error' | 'warning' | 'grounding_check' | 'status';
+  type: 'token' | 'references' | 'done' | 'error' | 'warning' | 'grounding_check' | 'status' | 'tool_call' | 'followups' | 'clarification';
   data?: any;
   status?: string;
   message?: string;
 }
 
-/**
- * Result of grounding validation.
- */
-export interface GroundingValidationResult {
-  isGrounded: boolean;
-  missingCitations: boolean;
-  issues: string[];
+export interface ChatAgentOptions {
+  vectorSearchHandler?: VectorSearchHandler;
 }
+
+// ============================================================
+// Constants
+// ============================================================
+
+const MAX_SEARCH_ITERATIONS = 3;
+
+const TOOL_DECISION_SYSTEM_PROMPT = `You are a study assistant helping a student understand their uploaded documents.
+
+Your job is to decide what information to retrieve before answering.
+
+RULES:
+1. You MUST call search_documents before answering any content question about the study material.
+2. You may skip searching ONLY for: greetings, meta-questions about the app itself, or follow-ups already fully covered by a prior tool result in this conversation.
+3. If the question is too ambiguous to search effectively, call ask_clarification instead.
+4. When calling search_documents, rephrase the question as a declarative statement for better retrieval (e.g. "photosynthesis converts light into chemical energy" not "How does photosynthesis work?").
+5. You may call search_documents multiple times with different queries to gather comprehensive information.`;
+
+const SEARCH_TOOL_DEF = {
+  name: 'search_documents',
+  description: "Search the user's uploaded documents for relevant information. Always call this before answering content questions.",
+  parameters: {
+    type: 'object' as const,
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Search query — rephrase the user question as a declarative statement for better retrieval',
+      },
+    },
+    required: ['query'],
+  },
+};
+
+const CLARIFY_TOOL_DEF = {
+  name: 'ask_clarification',
+  description: 'Ask the user to clarify their question when it is too ambiguous to search effectively.',
+  parameters: {
+    type: 'object' as const,
+    properties: {
+      question: {
+        type: 'string',
+        description: 'The clarifying question to show the user',
+      },
+    },
+    required: ['question'],
+  },
+};
 
 // ============================================================
 // Chat Agent Service
 // ============================================================
 
-export interface ChatAgentOptions {
-  /** When running in Convex, pass a handler that uses Convex vector search + ZeroEntropy reranking */
-  vectorSearchHandler?: VectorSearchHandler;
-}
-
-/**
- * Main chat agent class that orchestrates RAG-based chat responses.
- * For Convex backend, pass vectorSearchHandler so search uses Convex + reranking.
- */
 export class ChatAgent {
   private llmWrapper: ChatLLMWrapper;
   private vectorSearch: VectorSearchHandler;
   private embeddingService: EmbeddingService;
+  private decisionLlm: ChatTogetherAI;
 
   constructor(options?: ChatAgentOptions) {
-    // Initialize LLM wrapper
     this.llmWrapper = new ChatLLMWrapper({
       apiKey: env.TOGETHER_AI_API_KEY,
-      model: env.SMART_LLM || 'Qwen/Qwen3-Next-80B-A3B-Instruct',
+      model: env.SMART_LLM || 'openai/gpt-oss-120b',
       temperature: parseFloat(env.CHAT_LLM_TEMPERATURE ?? '0.1'),
+      fastModel: env.FAST_LLM,
+      fastApiKey: env.TOGETHER_AI_API_KEY,
     });
 
-    // Use injected handler (Convex) or build one that requires runner at search time
     this.vectorSearch =
       options?.vectorSearchHandler ??
       new VectorSearchHandler({
@@ -89,113 +119,169 @@ export class ChatAgent {
         maxResults: parseInt(env.CHAT_MAX_RESULTS ?? '7', 10),
       });
 
-    // Initialize embedding service for semantic grounding validation
     this.embeddingService = new EmbeddingService(env.OPENAI_API_KEY);
+
+    // Decision LLM for the tool-calling loop (temperature 0 for deterministic routing)
+    this.decisionLlm = new ChatTogetherAI({
+      apiKey: env.TOGETHER_AI_API_KEY,
+      model: env.SMART_LLM || 'openai/gpt-oss-120b',
+      temperature: 0,
+    });
   }
 
-  /**
-   * Streams response using strict RAG pattern (retrieve first, then generate).
-   *
-   * This eliminates agentic decision-making and ensures grounding by:
-   * 1. Retrieving relevant documents (deterministic, no LLM decision)
-   * 2. Generating structured output with citations
-   * 3. Validating grounding of the response
-   *
-   * @param context - Chat execution context
-   * @param userMessage - The user's question
-   * @yields Stream chunks with tokens, references, and status updates
-   */
-  async *streamResponse(context: ChatAgentContext, userMessage: string): AsyncGenerator<StreamChunk> {
-    console.log('[ChatAgent] ========== STREAM START (Strict RAG) ==========');
+  async *streamResponse(
+    context: ChatAgentContext,
+    userMessage: string
+  ): AsyncGenerator<StreamChunk> {
+    console.log('[ChatAgent] ========== STREAM START ==========');
     console.log(`[ChatAgent] User message: "${userMessage}"`);
-    console.log(`[ChatAgent] Context: noteId=${context.noteId}`);
 
     try {
-      // ============================================================
-      // PHASE 1: Retrieval (deterministic, no LLM decision)
-      // ============================================================
-
-      console.log('[ChatAgent] Phase 1: Retrieving relevant documents');
-      yield { type: 'status', status: 'searching', message: 'Searching relevant sources...' };
-
-      const chunks = await this.vectorSearch.search(
-        context.userId,
-        context.noteId,
-        userMessage,
-        context.documentIds
-      );
-
-      console.log(`[ChatAgent] Retrieved ${chunks.length} relevant chunks`);
-      yield { type: 'status', status: 'reading', message: `Reading ${chunks.length} sources...` };
-
-      // Immediately send references so user sees what's being used
-      yield { type: 'references', data: chunks };
-
-      // ============================================================
-      // PHASE 2: Generation with structured output
-      // ============================================================
-
-      console.log('[ChatAgent] Phase 2: Generating grounded response (structured output)');
-      yield { type: 'status', status: 'thinking', message: 'Analyzing sources and formulating response...' };
-
-      // Extract recent conversation turns (user + assistant pairs) for context
-      // Include last 3 pairs (6 messages) to help the LLM understand follow-up questions
       const recentTurns = context.conversationHistory.slice(-6);
+      const allChunks: ReferenceChunk[] = [];
 
-      console.log(`[ChatAgent] Including ${recentTurns.length} previous messages for context`);
+      // ============================================================
+      // PHASE 1: Tool-calling loop — LLM decides what to search
+      // ============================================================
 
-      // Generate structured response with citations and conversation context
-      const structuredResponse = await this.llmWrapper.generateStructuredResponse(
-        chunks,
+      console.log('[ChatAgent] Phase 1: Tool-calling decision loop');
+
+      const messages: BaseMessage[] = [
+        new SystemMessage(TOOL_DECISION_SYSTEM_PROMPT),
+        ...recentTurns.map((t) =>
+          t.role === 'user' ? new HumanMessage(t.content) : new AIMessage(t.content)
+        ),
+        new HumanMessage(userMessage),
+      ];
+
+      const llmWithTools = (this.decisionLlm as any).bindTools([SEARCH_TOOL_DEF, CLARIFY_TOOL_DEF]);
+
+      let iterations = 0;
+      while (iterations < MAX_SEARCH_ITERATIONS) {
+        const response = await llmWithTools.invoke(messages);
+        messages.push(response as AIMessage);
+
+        const toolCalls = (response as any).tool_calls as Array<{ name: string; args: any; id?: string }> | undefined;
+
+        if (!toolCalls || toolCalls.length === 0) {
+          // LLM decided no search needed (greeting, meta-question, etc.)
+          console.log('[ChatAgent] LLM skipped search — direct answer or no tools called');
+          break;
+        }
+
+        for (const call of toolCalls) {
+          if (call.name === 'ask_clarification') {
+            const question = call.args?.question ?? 'Could you clarify your question?';
+            console.log(`[ChatAgent] LLM requested clarification: "${question}"`);
+            yield { type: 'clarification', data: { question } };
+            yield { type: 'done' };
+            return;
+          }
+
+          if (call.name === 'search_documents') {
+            const query: string = call.args?.query ?? userMessage;
+            console.log(`[ChatAgent] search_documents called with query: "${query}"`);
+
+            yield { type: 'tool_call', data: { tool: 'search_documents', query, status: 'searching' } };
+
+            // HyDE: embed a hypothetical answer for better semantic matching
+            const hydeText = await this.llmWrapper.generateHypotheticalDocument(query);
+            const hydeEmbedding = await this.embeddingService.embedText(hydeText);
+
+            const newChunks = await this.vectorSearch.search(
+              context.userId,
+              context.noteId,
+              query,
+              context.documentIds,
+              hydeEmbedding
+            );
+
+            // Deduplicate by sourceId + chunkIndex
+            for (const chunk of newChunks) {
+              const key = `${chunk.sourceId}:${chunk.chunkIndex}`;
+              if (!allChunks.some((c) => `${c.sourceId}:${c.chunkIndex}` === key)) {
+                allChunks.push(chunk);
+              }
+            }
+
+            console.log(`[ChatAgent] search returned ${newChunks.length} chunks (total: ${allChunks.length})`);
+
+            yield {
+              type: 'tool_call',
+              data: { tool: 'search_documents', query, status: 'done', resultCount: newChunks.length },
+            };
+
+            messages.push(
+              new ToolMessage({
+                content: `Found ${newChunks.length} relevant passages.`,
+                tool_call_id: call.id ?? `call_${iterations}`,
+              })
+            );
+          }
+        }
+
+        iterations++;
+      }
+
+      if (allChunks.length === 0) {
+        throw new Error(
+          'No results found. The documents may not contain information relevant to your query.'
+        );
+      }
+
+      // Send references so the UI can show what's being used
+      yield { type: 'status', status: 'reading', message: `Reading ${allChunks.length} passages...` };
+      yield { type: 'references', data: allChunks };
+
+      // ============================================================
+      // PHASE 2: Generate structured response with citations
+      // ============================================================
+
+      console.log('[ChatAgent] Phase 2: Generating grounded response');
+      yield { type: 'status', status: 'thinking', message: 'Formulating answer...' };
+
+      let structuredResponse: ChatResponse = await this.llmWrapper.generateStructuredResponse(
+        allChunks,
         userMessage,
         recentTurns
       );
 
-      // Yield the answer as tokens for compatibility with existing streaming interface
-      yield { type: 'status', status: 'generating', message: 'Generating response...' };
-      const answerText = structuredResponse.answer_markdown;
-
-      // Stream by paragraphs/sentences for better Markdown rendering
-      // This preserves markdown formatting better than arbitrary character chunks
-      const paragraphs = answerText.split(/\n\n+/);
-      for (const para of paragraphs) {
-        if (para.trim().length > 0) {
-          yield { type: 'token', data: para + '\n\n' };
-          // Small delay for readability
-          await new Promise((resolve) => setTimeout(resolve, 30));
-        }
-      }
-
-      console.log(`[ChatAgent] Generated response length: ${answerText.length} characters`);
-
-      // Extract citations from markdown for logging
-      const citationMatches = [...answerText.matchAll(/\[(\d+)\]/g)];
-      const citedIndices = [...new Set(citationMatches.map((m) => parseInt(m[1])))]
-        .filter((n) => !isNaN(n))
-        .sort((a, b) => a - b);
-      console.log(
-        `[ChatAgent] Cited indices: [${citedIndices.join(', ')}], Confidence: ${structuredResponse.confidence}`
-      );
-
       // ============================================================
-      // PHASE 3: Validation (syntactic + semantic)
+      // PHASE 3: Grounding validation + one retry on failure
       // ============================================================
 
       console.log('[ChatAgent] Phase 3: Validating grounding');
 
-      // First, syntactic validation (citations exist and are valid)
-      const syntacticValidation = validateGrounding(answerText, chunks);
-
-      // Second, semantic validation (cited content actually supports claims)
-      console.log('[ChatAgent] Running semantic grounding validation...');
-      const semanticValidation = await validateSemanticGrounding(answerText, chunks, this.embeddingService);
-
-      // Combine both validation results
-      const allIssues = [...syntacticValidation.issues, ...semanticValidation.issues];
+      const syntacticValidation = validateGrounding(structuredResponse.answer_markdown, allChunks);
+      const semanticValidation = await validateSemanticGrounding(
+        structuredResponse.answer_markdown,
+        allChunks,
+        this.embeddingService
+      );
       const isGrounded = syntacticValidation.isGrounded && semanticValidation.isGrounded;
 
       if (!isGrounded) {
-        console.warn(`[ChatAgent] Grounding validation failed: ${allIssues.join(', ')}`);
+        console.warn('[ChatAgent] Grounding failed — retrying with strict grounding');
+        structuredResponse = await this.llmWrapper.generateWithStrictGrounding(
+          allChunks,
+          userMessage,
+          recentTurns
+        );
+      }
+
+      // Stream final answer by paragraphs
+      yield { type: 'status', status: 'generating', message: 'Generating response...' };
+      const finalText = structuredResponse.answer_markdown;
+      for (const para of finalText.split(/\n\n+/)) {
+        if (para.trim().length > 0) {
+          yield { type: 'token', data: para + '\n\n' };
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        }
+      }
+
+      // Surface grounding warning only after retry still failed
+      if (!isGrounded) {
+        const allIssues = [...syntacticValidation.issues, ...semanticValidation.issues];
         yield {
           type: 'grounding_check',
           data: {
@@ -204,11 +290,8 @@ export class ChatAgent {
             message: 'Note: This response may not be fully grounded in your documents',
           },
         };
-      } else {
-        console.log('[ChatAgent] Grounding validation passed (syntactic + semantic)');
       }
 
-      // Emit confidence score from structured output
       if (structuredResponse.confidence !== 'high') {
         yield {
           type: 'grounding_check',
@@ -220,33 +303,29 @@ export class ChatAgent {
         };
       }
 
+      // ============================================================
+      // PHASE 4: Follow-up question suggestions
+      // ============================================================
+
+      const followUps = await this.llmWrapper.generateFollowUpQuestions(userMessage, finalText);
+      if (followUps.length > 0) {
+        yield { type: 'followups', data: followUps };
+      }
+
       yield { type: 'done' };
 
-      console.log(`[ChatAgent] ========== STREAM COMPLETE ==========`);
-      console.log(
-        `[ChatAgent] Response: ${answerText.length} chars, Sources: ${chunks.length}, Validation: ${isGrounded ? 'PASSED' : 'FAILED'}`
-      );
+      console.log('[ChatAgent] ========== STREAM COMPLETE ==========');
     } catch (error) {
-      console.error('[ChatAgent] ========== ERROR ==========');
-      console.error('[ChatAgent] Error:', error);
+      console.error('[ChatAgent] ========== ERROR ==========', error);
 
-      // Classify error types for better user messaging
       let errorMessage = 'Unknown error occurred';
       let errorType = 'unknown';
 
       if (error instanceof Error) {
         errorMessage = error.message;
-
-        // Classify common errors
-        if (
-          error.message.includes('No results found') ||
-          error.message.includes('No relevant documents')
-        ) {
+        if (error.message.includes('No results found') || error.message.includes('No relevant documents')) {
           errorType = 'no_documents';
-        } else if (
-          error.message.includes('Vector search failed') ||
-          error.message.includes('Hybrid search failed')
-        ) {
+        } else if (error.message.includes('Vector search failed') || error.message.includes('Hybrid search failed')) {
           errorType = 'search_failed';
         } else if (error.message.includes('API key')) {
           errorType = 'api_error';
@@ -255,12 +334,7 @@ export class ChatAgent {
         }
       }
 
-      console.error(`[ChatAgent] Error type: ${errorType}, message: ${errorMessage}`);
-
-      yield {
-        type: 'error',
-        data: { message: errorMessage, type: errorType },
-      };
+      yield { type: 'error', data: { message: errorMessage, type: errorType } };
     }
   }
 }

--- a/convex/_agents/chat/hybrid_search.ts
+++ b/convex/_agents/chat/hybrid_search.ts
@@ -156,11 +156,12 @@ export class HybridSearchHandler extends VectorSearchHandler {
     userId: string,
     noteId: string,
     query: string,
-    documentIds?: string[]
+    documentIds?: string[],
+    preComputedEmbedding?: number[]
   ): Promise<HybridReferenceChunk[]> {
     if (!this.hybridConfig.enableHybrid || !this.keywordSearchRunner) {
       // Vector-only: cast to base type for compatibility
-      return (await super.search(userId, noteId, query, documentIds)) as HybridReferenceChunk[];
+      return (await super.search(userId, noteId, query, documentIds, preComputedEmbedding)) as HybridReferenceChunk[];
     }
 
     const startTime = Date.now();
@@ -169,7 +170,7 @@ export class HybridSearchHandler extends VectorSearchHandler {
     try {
       // Parallel retrieval
       const [vectorResults, keywordResults] = await Promise.all([
-        this.executeVectorSearch(query, documentIds),
+        this.executeVectorSearch(query, documentIds, preComputedEmbedding),
         this.executeKeywordSearch(query, documentIds),
       ]);
 
@@ -248,10 +249,10 @@ export class HybridSearchHandler extends VectorSearchHandler {
    */
   private async executeVectorSearch(
     query: string,
-    documentIds?: string[]
+    documentIds?: string[],
+    preComputedEmbedding?: number[]
   ): Promise<VectorSearchRawResult[]> {
-    // Access protected embeddingService via getter
-    const embedding = await this['embeddingService'].embedText(query);
+    const embedding = preComputedEmbedding ?? await this['embeddingService'].embedText(query);
     return await this['vectorSearchRunner'](embedding, this['config'].vectorMatchCount, documentIds);
   }
 

--- a/convex/_agents/chat/llm_wrapper.ts
+++ b/convex/_agents/chat/llm_wrapper.ts
@@ -36,10 +36,14 @@ export interface ChatResponse {
 export interface LLMWrapperConfig {
   /** TogetherAI API key */
   apiKey: string;
-  /** Model to use for generation */
+  /** Smart model for generation */
   model: string;
   /** Temperature for generation (default: 0.1) */
   temperature?: number;
+  /** Fast model for lightweight operations (HyDE, follow-ups). Falls back to smart model if omitted. */
+  fastModel?: string;
+  /** API key for fast model (defaults to apiKey) */
+  fastApiKey?: string;
 }
 
 // ============================================================
@@ -132,7 +136,12 @@ When paraphrasing, stay VERY close to original wording:
 - BAD: "The model is optimized to reproduce mappings [1]" (if source says "learns from labeled examples")
 - GOOD: "The model learns from labeled examples [1]"
 
-Your job is to REFLECT what the documents say, not enhance them with your training data.`;
+Your job is to REFLECT what the documents say, not enhance them with your training data.
+
+# PROHIBITED CLOSINGS
+- Do NOT end responses with meta-commentary like "Note: The above points are drawn directly from..."
+- Do NOT add any closing disclaimers about what sources do or don't contain
+- If sources are missing information, say so inline where relevant, then stop`;
 
 /**
  * Minimal few-shot examples (only used for first query or complex patterns).
@@ -172,8 +181,11 @@ A: {
 /**
  * Handles LLM response generation with structured output and citations.
  */
+const STRICT_GROUNDING_PREFIX = `IMPORTANT: A previous response was flagged for insufficient grounding. This time, ONLY state things that are word-for-word supported by the sources. When in doubt, write: "The sources do not contain enough information to answer this."\n\n`;
+
 export class ChatLLMWrapper {
   private llm: ChatTogetherAI;
+  private fastLlm: ChatTogetherAI;
   private tokenBudget: number = 7000; // Reserve tokens for generation
 
   constructor(config: LLMWrapperConfig) {
@@ -182,6 +194,75 @@ export class ChatLLMWrapper {
       model: config.model,
       temperature: config.temperature ?? 0.1,
     });
+    this.fastLlm = config.fastModel
+      ? new ChatTogetherAI({
+          apiKey: config.fastApiKey ?? config.apiKey,
+          model: config.fastModel,
+          temperature: 0.1,
+        })
+      : this.llm;
+  }
+
+  /**
+   * Generates a hypothetical document paragraph for HyDE retrieval.
+   * The resulting text is embedded instead of the raw query for better semantic search.
+   */
+  async generateHypotheticalDocument(query: string): Promise<string> {
+    console.log('[ChatLLMWrapper] Generating hypothetical document for HyDE');
+    const prompt = `Write a short, factual paragraph (2-4 sentences) that would directly answer this question if it appeared in a textbook or study material. Write as a statement of facts, not as an answer to a question.\n\nQuestion: ${query}`;
+    try {
+      const response = await this.fastLlm.invoke(
+        [new HumanMessage(prompt)],
+        { maxTokens: 150 } as any
+      );
+      const text = typeof response.content === 'string'
+        ? response.content.trim()
+        : String(response.content).trim();
+      console.log('[ChatLLMWrapper] HyDE document:', text.slice(0, 200));
+      return text || query;
+    } catch (error) {
+      console.warn('[ChatLLMWrapper] HyDE generation failed, falling back to raw query:', error);
+      return query;
+    }
+  }
+
+  /**
+   * Generates 2-3 follow-up question suggestions for a study session.
+   */
+  async generateFollowUpQuestions(userMessage: string, answer: string): Promise<string[]> {
+    console.log('[ChatLLMWrapper] Generating follow-up questions');
+    const truncatedAnswer = answer.length > 600 ? answer.slice(0, 600) + '...' : answer;
+    const prompt = `You are helping a student study. Based on this Q&A, suggest 2-3 short follow-up questions the student might naturally ask next.\n\nQuestion: ${userMessage}\nAnswer: ${truncatedAnswer}\n\nReturn ONLY a JSON array of strings, e.g. ["Question 1?", "Question 2?", "Question 3?"]`;
+    try {
+      const response = await this.fastLlm.invoke(
+        [new HumanMessage(prompt)],
+        { maxTokens: 120 } as any
+      );
+      const text = typeof response.content === 'string' ? response.content.trim() : String(response.content).trim();
+      const match = text.match(/\[[\s\S]*\]/);
+      if (match) {
+        const parsed = JSON.parse(match[0]);
+        if (Array.isArray(parsed)) {
+          return parsed.slice(0, 3).map(String).filter(Boolean);
+        }
+      }
+      return [];
+    } catch (error) {
+      console.warn('[ChatLLMWrapper] Follow-up question generation failed:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Re-generates a response with stricter grounding constraints after a validation failure.
+   */
+  async generateWithStrictGrounding(
+    chunks: ReferenceChunk[],
+    userMessage: string,
+    conversationHistory: Array<{ role: string; content: string }> = []
+  ): Promise<ChatResponse> {
+    console.log('[ChatLLMWrapper] Retrying with strict grounding');
+    return this._generateStructuredResponse(chunks, userMessage, conversationHistory, true);
   }
 
   /**
@@ -189,7 +270,7 @@ export class ChatLLMWrapper {
    *
    * @param chunks - Reference chunks to use as context
    * @param userMessage - The user's question
-   * @param userQuestions - Previous user questions for context
+   * @param conversationHistory - Previous conversation turns for context
    * @returns Structured chat response with citations
    */
   async generateStructuredResponse(
@@ -197,18 +278,28 @@ export class ChatLLMWrapper {
     userMessage: string,
     conversationHistory: Array<{ role: string; content: string }> = []
   ): Promise<ChatResponse> {
+    return this._generateStructuredResponse(chunks, userMessage, conversationHistory, false);
+  }
+
+  private async _generateStructuredResponse(
+    chunks: ReferenceChunk[],
+    userMessage: string,
+    conversationHistory: Array<{ role: string; content: string }>,
+    strictGrounding: boolean
+  ): Promise<ChatResponse> {
     console.log('[ChatLLMWrapper] Generating structured response with citations');
 
     // Conditional few-shot: only for first query or complex patterns
     const needsExamples = conversationHistory.length === 0 || this.isComplexQuery(userMessage);
-    
+
     // Inject current date so the model knows "today" vs historical document dates
     const today = new Date().toISOString().split('T')[0];
     const dateContext = `\nCurrent Date: ${today}`;
 
-    const systemPrompt = needsExamples
+    const basePrompt = needsExamples
       ? `${MINIMAL_FEW_SHOT}\n\n${CORE_SYSTEM_PROMPT}${dateContext}`
       : `${CORE_SYSTEM_PROMPT}${dateContext}`;
+    const systemPrompt = strictGrounding ? `${STRICT_GROUNDING_PREFIX}${basePrompt}` : basePrompt;
 
     // Create model with structured output
     // Use 'any' to avoid deep type instantiation issues

--- a/convex/_agents/chat/vector_search.ts
+++ b/convex/_agents/chat/vector_search.ts
@@ -105,7 +105,8 @@ export class VectorSearchHandler {
     userId: string,
     noteId: string,
     query: string,
-    documentIds?: string[]
+    documentIds?: string[],
+    preComputedEmbedding?: number[]
   ): Promise<ReferenceChunk[]> {
     if (!this.embeddingService || !this.vectorSearchRunner) {
       throw new Error(
@@ -118,7 +119,10 @@ export class VectorSearchHandler {
       `[VectorSearch] params: threshold=${this.config.vectorMatchThreshold}, count=${this.config.vectorMatchCount}, rerankTopN=${this.config.rerankTopN}`
     );
 
-    const queryEmbedding = await this.embeddingService.embedText(query);
+    if (preComputedEmbedding) {
+      console.log('[VectorSearch] Using pre-computed HyDE embedding');
+    }
+    const queryEmbedding = preComputedEmbedding ?? await this.embeddingService.embedText(query);
     let raw = await this.vectorSearchRunner(
       queryEmbedding,
       this.config.vectorMatchCount,

--- a/convex/chat/messages.ts
+++ b/convex/chat/messages.ts
@@ -177,6 +177,28 @@ export const sendMessageOptimistic = mutation({
 });
 
 /**
+ * Set thumbs up/down feedback on an assistant message.
+ * Pass null to remove existing feedback.
+ */
+export const setMessageFeedback = mutation({
+  args: {
+    messageId: v.id("messages"),
+    feedback: v.union(v.literal("up"), v.literal("down"), v.null()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Unauthenticated");
+
+    const message = await ctx.db.get(args.messageId);
+    if (!message) throw new Error("Message not found");
+
+    await ctx.db.patch(args.messageId, {
+      feedback: args.feedback ?? undefined,
+    });
+  },
+});
+
+/**
  * Clear all messages for a notebook
  */
 export const clearHistory = mutation({

--- a/convex/chat/stream.ts
+++ b/convex/chat/stream.ts
@@ -321,6 +321,12 @@ export async function streamChatResponse(
       } else if (chunk.type === "grounding_check") {
         // Append grounding check as metadata
         await chunkAppender(`\n__GROUNDING:${JSON.stringify(chunk.data)}\n`);
+      } else if (chunk.type === "tool_call") {
+        await chunkAppender(`\n__TOOL_CALL:${JSON.stringify(chunk.data)}\n`);
+      } else if (chunk.type === "followups") {
+        await chunkAppender(`\n__FOLLOWUPS:${JSON.stringify(chunk.data)}\n`);
+      } else if (chunk.type === "clarification") {
+        await chunkAppender(`\n__CLARIFICATION:${JSON.stringify(chunk.data)}\n`);
       } else if (chunk.type === "error") {
         hasError = true;
         await chunkAppender(`\n__ERROR:${JSON.stringify(chunk.data)}\n`);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -249,6 +249,7 @@ export default defineSchema({
     content: v.string(),
     references: v.optional(v.array(v.any())),
     metadata: v.optional(v.any()),
+    feedback: v.optional(v.union(v.literal("up"), v.literal("down"))),
     createdAt: v.number(),
   })
     .index("by_conversation", ["conversationId"]),


### PR DESCRIPTION
## Summary

- **Constrained tool-calling loop**: LLM now decides when to call `search_documents` (with HyDE embeddings) or `ask_clarification`, replacing the deterministic 3-step pipeline
- **HyDE retrieval**: Fast LLM generates a hypothetical answer paragraph, embeds it for better semantic search
- **Grounding retry**: If validation fails, regenerates with a stricter prompt before giving up
- **Follow-up chips**: 3 suggested follow-up questions streamed after each response, shown as clickable chips
- **Thumbs up/down feedback**: Persisted to DB via new `feedback` field on messages
- **Thinking animation**: Bouncing dots appear immediately on send, before first token arrives
- **Tool-call trace**: Animated search steps shown above streaming message
- **Empty state**: Starter prompt chips when conversation is empty
- **ChatPanel refactor**: Monolithic 770-line file split into `MessageBubble`, `ReferenceTooltip`, `ChatEmptyState`, `ChatInput`, `utils/messageRendering`, `utils/messageStatus`
- **Model updates**: `SMART_LLM=openai/gpt-oss-120b`, `FAST_LLM=Qwen/Qwen3.5-9B`
- **Prompt fix**: Suppress redundant trailing meta-commentary from LLM responses

## Test plan

- [ ] Send a message and verify thinking dots appear immediately
- [ ] Verify tool-call trace rows appear before response text
- [ ] Verify follow-up chips appear below completed responses and clicking one sends that message
- [ ] Verify thumbs up/down toggle correctly (green/red highlight, persists on refresh)
- [ ] Open app with no messages — verify empty state with starter chips
- [ ] Click a starter chip — verify it sends and chips disappear
- [ ] Verify citation hover tooltips still work
- [ ] Run `bun run typecheck:web` and `bun run typecheck:convex` — both should pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)