### PR TITLE
fix(prompts): GFM pipe tables vs LaTeX | in shared math rules

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^7.1.8",
     "@sentry/react-native": "^8.8.0",
-    "convex": "^1.34.1",
+    "convex": "1.34.1",
     "expo": "~55.0.0",
     "expo-audio": "^55.0.13",
     "expo-constants": "~55.0.14",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^7.1.8",
     "@sentry/react-native": "^8.8.0",
-    "convex": "^1.35.1",
+    "convex": "^1.34.1",
     "expo": "~55.0.0",
     "expo-audio": "^55.0.13",
     "expo-constants": "~55.0.14",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^7.1.8",
     "@sentry/react-native": "^8.8.0",
-    "convex": "1.34.1",
+    "convex": "1.36.0",
     "expo": "~55.0.0",
     "expo-audio": "^55.0.13",
     "expo-constants": "~55.0.14",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "@stripe/stripe-js": "^8.6.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
-    "convex": "^1.34.1",
+    "convex": "1.34.1",
     "dompurify": "^3.2.3",
     "katex": "^0.16.27",
     "langchain": "^1.2.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "@stripe/stripe-js": "^8.6.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
-    "convex": "1.34.1",
+    "convex": "1.36.0",
     "dompurify": "^3.2.3",
     "katex": "^0.16.27",
     "langchain": "^1.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.2",
         "@typescript/native-preview": "^7.0.0-dev.20260409.1",
-        "convex": "^1.34.1",
+        "convex": "1.34.1",
         "eslint": "9",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.0",
@@ -53,7 +53,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/native": "^7.1.8",
         "@sentry/react-native": "^8.8.0",
-        "convex": "^1.34.1",
+        "convex": "1.34.1",
         "expo": "~55.0.0",
         "expo-audio": "^55.0.13",
         "expo-constants": "~55.0.14",
@@ -96,7 +96,7 @@
         "@stripe/stripe-js": "^8.6.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
-        "convex": "^1.34.1",
+        "convex": "1.34.1",
         "dompurify": "^3.2.3",
         "katex": "^0.16.27",
         "langchain": "^1.2.3",
@@ -2672,8 +2672,6 @@
     "@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.6", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.6" } }, "sha512-l+yQ2fuIgR//wszUlMrrAa9+Z+kbKazd0QOh0VQY7jC4ghb7yZBBSla/UMYRBZZ6fPg9IM+wD3+h+37a5f9etw=="],
 
     "@react-native/dev-middleware/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@solomindlm/mobile/convex": ["convex@1.35.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ=="],
 
     "@solomindlm/web/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@types/bun": "^1.3.11",
         "@types/node": "^25.5.2",
         "@typescript/native-preview": "^7.0.0-dev.20260409.1",
-        "convex": "1.34.1",
+        "convex": "1.36.0",
         "eslint": "9",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.0",
@@ -53,7 +53,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/native": "^7.1.8",
         "@sentry/react-native": "^8.8.0",
-        "convex": "1.34.1",
+        "convex": "1.36.0",
         "expo": "~55.0.0",
         "expo-audio": "^55.0.13",
         "expo-constants": "~55.0.14",
@@ -96,7 +96,7 @@
         "@stripe/stripe-js": "^8.6.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
-        "convex": "1.34.1",
+        "convex": "1.36.0",
         "dompurify": "^3.2.3",
         "katex": "^0.16.27",
         "langchain": "^1.2.3",
@@ -1165,7 +1165,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.34.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-ooyFnZVVq0u6b5zt0Ptq8QB2ixhf/2vXe+PIcUtdtrs0lq/TwpkmmruHdqkFmWgMd6N+Tmfy8AGkz6QnZUYZBA=="],
+    "convex": ["convex@1.36.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-17cfDr2z+Apd59291rKWij6jq79eVwzY9u2MQOnuVkOsfEPXcuerWHQLf1ngXAbQjeTXD1nwQYsxQBhZnjZMIQ=="],
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
 
@@ -2730,8 +2730,6 @@
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "convex/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/native": "^7.1.8",
         "@sentry/react-native": "^8.8.0",
-        "convex": "^1.35.1",
+        "convex": "^1.34.1",
         "expo": "~55.0.0",
         "expo-audio": "^55.0.13",
         "expo-constants": "~55.0.14",

--- a/convex/_agents/_shared/markdownMathPrompt.ts
+++ b/convex/_agents/_shared/markdownMathPrompt.ts
@@ -11,6 +11,7 @@ export const MARKDOWN_MATH_RULES_BULLETS = `- Inline math: one pair of dollar si
 - Every expression that uses backslash-LaTeX (\\sum, \\beta, \\dots, \\tag, etc.), Greek letters, or subscripts/superscripts meant as math must lie entirely inside $...$ or $$...$$; undelimited lines show as broken raw text.
 - Use KaTeX-supported LaTeX only (no custom packages or unsupported environments). \\tag{n} on display equations is allowed when needed.
 - Place citation markers like [1] in normal text after math or on the following line — never between the opening and closing $ of one inline math span.
-- Prefer citations after a closing parenthesis or delimiter, e.g. $(\\beta_0 + \\sum_j X_{j,t})$ [1], not $(\\beta_0 + \\sum_j X_{j,t} [1])$, so they stay clickable in the app.`;
+- Prefer citations after a closing parenthesis or delimiter, e.g. $(\\beta_0 + \\sum_j X_{j,t})$ [1], not $(\\beta_0 + \\sum_j X_{j,t} [1])$, so they stay clickable in the app.
+- **GFM pipe tables (| col | col |):** Every ASCII | starts a new column, even inside $...$ or $$...$$, which splits formulas and breaks rendering (e.g. $\\hat{y}_{t+h|t}$ becomes two cells). **Never** use a raw | for math vertical bars in table cells. Use LaTeX instead: e.g. $\\hat{y}_{t+h\\mid t}$, $P(A\\mid B)$, or $\\lvert x \\rvert$. For a dense grid of equations, prefer one $$...$$ per line, a bullet list, or a table in HTML; avoid pipe tables when any cell would need |.`;
 
 export const MARKDOWN_MATH_NOTATION_FOR_APP = `**Math notation (Markdown with KaTeX — required for correct rendering in the app):**\n${MARKDOWN_MATH_RULES_BULLETS}`;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.2",
     "@typescript/native-preview": "^7.0.0-dev.20260409.1",
-    "convex": "1.34.1",
+    "convex": "1.36.0",
     "eslint": "9",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/bun": "^1.3.11",
     "@types/node": "^25.5.2",
     "@typescript/native-preview": "^7.0.0-dev.20260409.1",
-    "convex": "^1.34.1",
+    "convex": "1.34.1",
     "eslint": "9",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.0",


### PR DESCRIPTION
## Summary
Adds a shared bullet in `markdownMathPrompt.ts` so report/studio models avoid raw ASCII `|` inside GFM table cells. Markdown treats `|` as a column separator even inside `$...$` math, which was breaking expressions like `\\hat{y}_{t+h|t}`.

## Change
- Prefer `\\mid`, `\\vert`, or `\\lvert x \\rvert` for vertical bars in math when using pipe tables; suggest `$$...$$` lines, lists, or HTML tables when a grid is too `|`-heavy.


Made with [Cursor](https://cursor.com)