### PR TITLE
fix: regenerate bun lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,17 +12,18 @@
         "@convex-dev/persistent-text-streaming": "^0.3.2",
         "@convex-dev/rate-limiter": "^0.3.2",
         "@convex-dev/stripe": "^0.1.4",
+        "@convex-dev/workflow": "^0.3.12",
         "@convex-dev/workpool": "^0.3.2",
         "@langchain/community": "^1.1.28",
-        "@langchain/core": "^1.1.44",
-        "@langchain/langgraph": "^1.2.9",
+        "@langchain/core": "^1.1.45",
+        "@langchain/langgraph": "^1.3.0",
         "@langchain/openai": "^1.4.5",
         "@langchain/textsplitters": "^1.0.1",
         "@oslojs/crypto": "^1.0.1",
         "@standard-schema/spec": "^1.1.0",
         "@supadata/js": "^1.4.0",
         "@tavily/core": "^0.7.3",
-        "convex-helpers": "^0.1.115",
+        "convex-helpers": "^0.1.116",
         "langsmith": "^0.4.12",
         "p-limit": "^7.3.0",
         "resend": "^4.8.0",
@@ -35,8 +36,8 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.59.1",
         "@types/bun": "^1.3.13",
-        "@types/node": "^25.6.0",
-        "@typescript/native-preview": "^7.0.0-dev.20260504.1",
+        "@types/node": "^25.6.2",
+        "@typescript/native-preview": "^7.0.0-dev.20260508.1",
         "convex": "1.36.0",
         "convex-test": "^0.0.50",
         "dotenv": "^17.4.2",
@@ -382,6 +383,8 @@
     "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
     "@convex-dev/stripe": ["@convex-dev/stripe@0.1.4", "", { "dependencies": { "stripe": "^20.0.0" }, "peerDependencies": { "convex": "^1.29.3", "react": "^18.3.1 || ^19.0.0" } }, "sha512-HnINm3K2QHGvP0X4YV7KruCjQ1Ni0HE1qpJ5rZYjfdUbMcqJsX4ZYTmOo7tL83qtokS3EahKVkhXLCH/9Ms/og=="],
+
+    "@convex-dev/workflow": ["@convex-dev/workflow@0.3.12", "", { "dependencies": { "async-channel": "^0.2.0" }, "peerDependencies": { "@convex-dev/workpool": "^0.3.0 || ^0.4.0", "convex": "^1.31.7", "convex-helpers": "^0.1.99" } }, "sha512-4c4eSe2sXnhxE6Td4benRg6OMJahWkOHdLv++FxpjZVZUANFmJqYKZxx8Bxqs0SB4ECGd2j0MZalNppLPKxQ7Q=="],
 
     "@convex-dev/workpool": ["@convex-dev/workpool@0.3.2", "", { "peerDependencies": { "convex": "^1.31.7", "convex-helpers": "^0.1.94" } }, "sha512-jNPBHLCmZQXaztbBntZgIoM8JhKDmGwaIezZS/zPmX74PzON0Fgysgd9u+NOjJ04Dx2pN8ppBH9ElpsKxCOBpA=="],
 
@@ -1112,6 +1115,8 @@
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
+
+    "async-channel": ["async-channel@0.2.0", "", {}, "sha512-BJyjI/sfKlyijaBt2hbOSxT28xGNtLR0QLzAKO1Hlnv5BULY7sAoYoTPW3lfr1ZIC7y+FxabxO9T8GXpyoofGg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 


### PR DESCRIPTION
## Summary
Fixes CI failures caused by stale Bun lockfile.

## Problem
All CI jobs failed with:
```
error: lockfile had changes, but lockfile is frozen
```

## Fix
Ran `bun install` to regenerate `bun.lock` and sync it with `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)