### PR TITLE
fix: literature review incomplete extraction tables

### DIFF
--- a/convex/_agents/literature_review/prompts.ts
+++ b/convex/_agents/literature_review/prompts.ts
@@ -229,7 +229,7 @@ Use the abstract and title as your primary sources. If the exact information is 
 Only use "N/A" as a last resort when the information is truly impossible to infer from the available text.
 Keep extractions concise but complete (1-3 sentences per cell).
 
-Respond in the following JSON format exactly (use one key per column id from EXTRACTION COLUMNS above):
+Respond in the following JSON format exactly. Each key in extractedData MUST be the exact column id string from EXTRACTION COLUMNS (e.g. framework_name), never the display name:
 
 {\n  "extractedData": {\n    "column_id_from_definitions": "Extracted value for that column",\n    "another_column_id": "Another extracted value"\n  }\n}
 

--- a/convex/literatureReview/db.test.ts
+++ b/convex/literatureReview/db.test.ts
@@ -517,6 +517,48 @@ describe("insertDraftBatch with custom columns", () => {
     expect(drafts[0].rowData["sample_size"]).toBe("N = 245");
   });
 
+  test("aligns LLM keys that use display names to configured column ids", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t);
+    const notebookId = await seedNotebook(t, userId);
+    const sessionId = await seedSession(t, notebookId, userId);
+
+    await t.mutation(internal.literatureReview.db.insertDraftBatch, {
+      sessionId,
+      papers: [
+        {
+          title: "Paper One",
+          authors: ["Smith, J."],
+          year: 2023,
+          abstract: "Abstract one",
+          url: "http://example.com/1",
+          source: "arxiv" as const,
+          score: 0.9,
+          isIncluded: true,
+          extractedData: {
+            "Framework Name": "Retrieval-augmented pipeline",
+            "Performance Metrics": "Accuracy 91%",
+          },
+        },
+      ],
+      columns: [
+        { id: "framework_name", name: "Framework Name", isVisible: true },
+        { id: "performance_metrics", name: "Performance Metrics", isVisible: true },
+      ],
+      batchNumber: 0,
+    });
+
+    const drafts = await t.run(async (ctx) =>
+      ctx.db
+        .query("literatureTableDrafts")
+        .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+        .collect()
+    );
+
+    expect(drafts[0].rowData.framework_name).toBe("Retrieval-augmented pipeline");
+    expect(drafts[0].rowData.performance_metrics).toBe("Accuracy 91%");
+  });
+
   test("falls back to basic metadata when rowData is not provided", async () => {
     const t = convexTest(schema, modules);
     const userId = await seedUser(t);

--- a/convex/literatureReview/db.ts
+++ b/convex/literatureReview/db.ts
@@ -2,7 +2,11 @@ import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { internalMutation, internalQuery } from "../_generated/server";
 import { compactPapersForSnapshot } from "./rankedPapersSnapshot.js";
-import { formatPaperTitleYear, isTitleLikeColumnName } from "./reportContext.js";
+import {
+  alignExtractedDataToColumns,
+  formatPaperTitleYear,
+  isTitleLikeColumnName,
+} from "./reportContext.js";
 import {
   fallbackReviewTitleFromQuery,
   literatureReportTitle,
@@ -116,8 +120,10 @@ export const insertDraftBatch = internalMutation({
         citationKey,
       });
 
-      // Start with extracted data and always merge basic metadata so title/authors/year/summary are present
-      const rowData: Record<string, string> = paper.extractedData ? { ...paper.extractedData } : {};
+      // Start with extracted data aligned to column ids (LLM keys often use display names)
+      const rowData: Record<string, string> = paper.extractedData
+        ? alignExtractedDataToColumns(paper.extractedData, args.columns)
+        : {};
 
       // Always inject core bibliographic fields regardless of column configuration
       rowData["title"] = paper.title;

--- a/convex/literatureReview/reportContext.test.ts
+++ b/convex/literatureReview/reportContext.test.ts
@@ -9,6 +9,7 @@ import {
   mergeDeterministicReportSections,
   needsDeterministicReportMerge,
   normalizeLiteratureReportSectionContent,
+  alignExtractedDataToColumns,
   resolveStudyTableCellValue,
   stripLeadingSectionHeadingLine,
   validateAndSanitizeReportSections,
@@ -128,6 +129,21 @@ describe("reportContext", () => {
     ).toBe(false);
   });
 
+  it("alignExtractedDataToColumns maps display-name keys to column ids", () => {
+    const aligned = alignExtractedDataToColumns(
+      {
+        "Framework Name": "Transformer-based RAG",
+        performance_metrics: "F1 0.82 on benchmark X",
+      },
+      [
+        { id: "framework_name", name: "Framework Name" },
+        { id: "performance_metrics", name: "Performance Metrics" },
+      ]
+    );
+    expect(aligned.framework_name).toBe("Transformer-based RAG");
+    expect(aligned.performance_metrics).toBe("F1 0.82 on benchmark X");
+  });
+
   it("buildStudyCharacteristicsTable renders rows", () => {
     const table = buildStudyCharacteristicsTable(
       [
@@ -139,10 +155,27 @@ describe("reportContext", () => {
           rowData: { domain: "medicine" },
         },
       ],
-      ["domain"]
+      [{ id: "domain", name: "Domain" }]
     );
     expect(table).toContain("Kim2026");
     expect(table).toContain("medicine");
+  });
+
+  it("buildStudyCharacteristicsTable resolves cells by column id when name differs", () => {
+    const table = buildStudyCharacteristicsTable(
+      [
+        {
+          citationKey: "Liu2026",
+          title: "Example",
+          authors: "Liu, D.",
+          year: "2026",
+          rowData: { framework_name: "Multi-agent orchestration" },
+        },
+      ],
+      [{ id: "framework_name", name: "Framework Name" }]
+    );
+    expect(table).toContain("Framework Name");
+    expect(table).toContain("Multi-agent orchestration");
   });
 
   it("resolveStudyTableCellValue backfills Paper Title & Year from metadata", () => {

--- a/convex/literatureReview/reportContext.test.ts
+++ b/convex/literatureReview/reportContext.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  alignExtractedDataToColumns,
   buildPrismaMethodsBlock,
   buildStudyCharacteristicsTable,
+  columnsForExtraction,
   findUnknownCitationKeys,
   fullReportHasOnlyTrivialContent,
   getReportSectionsNeedingRegeneration,
@@ -9,7 +11,6 @@ import {
   mergeDeterministicReportSections,
   needsDeterministicReportMerge,
   normalizeLiteratureReportSectionContent,
-  alignExtractedDataToColumns,
   resolveStudyTableCellValue,
   stripLeadingSectionHeadingLine,
   validateAndSanitizeReportSections,
@@ -142,6 +143,66 @@ describe("reportContext", () => {
     );
     expect(aligned.framework_name).toBe("Transformer-based RAG");
     expect(aligned.performance_metrics).toBe("F1 0.82 on benchmark X");
+  });
+
+  it("alignExtractedDataToColumns prefers column id when id and display name conflict", () => {
+    const aligned = alignExtractedDataToColumns(
+      {
+        framework_name: "Id-key value",
+        "Framework Name": "Display-name value",
+      },
+      [{ id: "framework_name", name: "Framework Name" }]
+    );
+    expect(aligned.framework_name).toBe("Id-key value");
+  });
+
+  it("alignExtractedDataToColumns drops empty and N/A values", () => {
+    const aligned = alignExtractedDataToColumns(
+      {
+        framework_name: "N/A",
+        performance_metrics: "   ",
+        sample_size: "N = 120",
+      },
+      [
+        { id: "framework_name", name: "Framework Name" },
+        { id: "performance_metrics", name: "Performance Metrics" },
+        { id: "sample_size", name: "Sample Size" },
+      ]
+    );
+    expect(aligned.framework_name).toBeUndefined();
+    expect(aligned.performance_metrics).toBeUndefined();
+    expect(aligned.sample_size).toBe("N = 120");
+  });
+
+  it("alignExtractedDataToColumns skips ambiguous compact-key collisions", () => {
+    const aligned = alignExtractedDataToColumns(
+      {
+        sample_size: "From underscore key",
+        "sample size": "From spaced key",
+      },
+      [{ id: "samplesize", name: "Size" }]
+    );
+    expect(aligned.samplesize).toBeUndefined();
+  });
+
+  it("columnsForExtraction returns only non-metadata columns", () => {
+    const columns = [
+      { id: "title", name: "Title" },
+      { id: "authors", name: "Authors" },
+      { id: "framework_name", name: "Framework Name" },
+    ];
+    expect(columnsForExtraction(columns)).toEqual([
+      { id: "framework_name", name: "Framework Name" },
+    ]);
+  });
+
+  it("columnsForExtraction returns empty when only metadata columns exist", () => {
+    expect(
+      columnsForExtraction([
+        { id: "title", name: "Title" },
+        { id: "year", name: "Year" },
+      ])
+    ).toEqual([]);
   });
 
   it("buildStudyCharacteristicsTable renders rows", () => {

--- a/convex/literatureReview/reportContext.ts
+++ b/convex/literatureReview/reportContext.ts
@@ -17,6 +17,80 @@ export type ReportPaperRow = {
   rowData: Record<string, string>;
 };
 
+/** Row keys filled from citations — not sent to the extraction LLM. */
+export const LITERATURE_METADATA_COLUMN_IDS = new Set([
+  "title",
+  "authors",
+  "year",
+  "summary",
+]);
+
+export type ExtractionColumnDef = { id: string; name: string };
+
+function normalizeColumnKey(key: string): string {
+  return key.toLowerCase().replace(/\s+/g, "_");
+}
+
+function compactColumnKey(key: string): string {
+  return normalizeColumnKey(key).replace(/_/g, "");
+}
+
+function isEmptyExtractionValue(value: string | undefined): boolean {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length === 0 || trimmed.toUpperCase() === "N/A";
+}
+
+/**
+ * Map LLM extraction keys (often display names) onto configured column ids.
+ * The studio table reads `rowData[columnId]` only — mismatched keys show as empty cells.
+ */
+export function alignExtractedDataToColumns(
+  extractedData: Record<string, string>,
+  columns: ExtractionColumnDef[]
+): Record<string, string> {
+  const byNormalizedKey = new Map<string, string>();
+  for (const [key, value] of Object.entries(extractedData)) {
+    if (isEmptyExtractionValue(value)) continue;
+    const trimmed = value.trim();
+    byNormalizedKey.set(normalizeColumnKey(key), trimmed);
+    byNormalizedKey.set(compactColumnKey(key), trimmed);
+    byNormalizedKey.set(key.toLowerCase(), trimmed);
+  }
+
+  const aligned: Record<string, string> = {};
+  for (const col of columns) {
+    if (LITERATURE_METADATA_COLUMN_IDS.has(col.id.toLowerCase())) continue;
+
+    const directCandidates = [col.id, col.name, normalizeColumnKey(col.name)];
+    for (const candidate of directCandidates) {
+      const direct = extractedData[candidate];
+      if (!isEmptyExtractionValue(direct)) {
+        aligned[col.id] = direct!.trim();
+        break;
+      }
+    }
+    if (aligned[col.id]) continue;
+
+    const idNorm = normalizeColumnKey(col.id);
+    const idCompact = compactColumnKey(col.id);
+    const nameCompact = compactColumnKey(col.name);
+    for (const [key, value] of byNormalizedKey) {
+      const keyCompact = key.replace(/_/g, "");
+      if (key === idNorm || keyCompact === idCompact || keyCompact === nameCompact) {
+        aligned[col.id] = value;
+        break;
+      }
+    }
+  }
+
+  return aligned;
+}
+
+export function columnsForExtraction<T extends ExtractionColumnDef>(columns: T[]): T[] {
+  const custom = columns.filter((c) => !LITERATURE_METADATA_COLUMN_IDS.has(c.id.toLowerCase()));
+  return custom.length > 0 ? custom : columns;
+}
+
 export type LiteratureReportContext = {
   query: string;
   reviewTitle?: string;
@@ -229,18 +303,24 @@ export function fullReportHasOnlyTrivialContent(
   );
 }
 
+export type StudyTableColumnRef = string | ExtractionColumnDef;
+
+function resolveStudyTableColumns(columns: StudyTableColumnRef[]): ExtractionColumnDef[] {
+  return columns
+    .map((col) => (typeof col === "string" ? { id: col, name: col } : col))
+    .filter((col) => !LITERATURE_METADATA_COLUMN_IDS.has(col.id.toLowerCase()));
+}
+
 export function buildStudyCharacteristicsTable(
   papers: ReportPaperRow[],
-  columnNames: string[]
+  columns: StudyTableColumnRef[]
 ): string {
   if (papers.length === 0) {
     return "_No included studies._";
   }
 
-  const displayCols = columnNames.filter(
-    (n) => !["title", "authors", "year", "summary"].includes(n.toLowerCase())
-  );
-  const headers = ["Study", "Year", ...displayCols.slice(0, 4)];
+  const displayCols = resolveStudyTableColumns(columns).slice(0, 4);
+  const headers = ["Study", "Year", ...displayCols.map((c) => c.name)];
 
   const rows = papers.map((p) => {
     const authorLabel = p.authors.split(",")[0]?.trim() ?? "Unknown";
@@ -248,8 +328,9 @@ export function buildStudyCharacteristicsTable(
     const cells = [
       studyCell,
       p.year || "N/A",
-      ...displayCols.slice(0, 4).map((col) => {
-        const val = resolveStudyTableCellValue(p, col);
+      ...displayCols.map((col) => {
+        const val =
+          resolveStudyTableCellValue(p, col.id) || resolveStudyTableCellValue(p, col.name);
         const trimmed = val.slice(0, 120);
         return trimmed || "—";
       }),

--- a/convex/literatureReview/reportContext.ts
+++ b/convex/literatureReview/reportContext.ts
@@ -17,13 +17,8 @@ export type ReportPaperRow = {
   rowData: Record<string, string>;
 };
 
-/** Row keys filled from citations — not sent to the extraction LLM. */
-export const LITERATURE_METADATA_COLUMN_IDS = new Set([
-  "title",
-  "authors",
-  "year",
-  "summary",
-]);
+/** Citation-backed row keys; excluded from custom-column extraction prompts and alignment. */
+export const LITERATURE_METADATA_COLUMN_IDS = new Set(["title", "authors", "year", "summary"]);
 
 export type ExtractionColumnDef = { id: string; name: string };
 
@@ -40,6 +35,34 @@ function isEmptyExtractionValue(value: string | undefined): boolean {
   return trimmed.length === 0 || trimmed.toUpperCase() === "N/A";
 }
 
+const AMBIGUOUS_EXTRACTED_KEY = Symbol("ambiguousExtractedKey");
+
+type ExtractedKeyIndex = Map<string, string | typeof AMBIGUOUS_EXTRACTED_KEY>;
+
+/** Index LLM keys under normalized/compact/lowercase aliases; mark aliases with conflicting values ambiguous. */
+function indexExtractedDataByKey(extractedData: Record<string, string>): ExtractedKeyIndex {
+  const index: ExtractedKeyIndex = new Map();
+  for (const [key, value] of Object.entries(extractedData)) {
+    if (isEmptyExtractionValue(value)) continue;
+    const trimmed = value.trim();
+    for (const alias of [normalizeColumnKey(key), compactColumnKey(key), key.toLowerCase()]) {
+      const existing = index.get(alias);
+      if (existing === undefined) {
+        index.set(alias, trimmed);
+      } else if (existing !== AMBIGUOUS_EXTRACTED_KEY && existing !== trimmed) {
+        index.set(alias, AMBIGUOUS_EXTRACTED_KEY);
+      }
+    }
+  }
+  return index;
+}
+
+function lookupIndexedValue(index: ExtractedKeyIndex, alias: string): string | undefined {
+  const hit = index.get(alias);
+  if (hit === undefined || hit === AMBIGUOUS_EXTRACTED_KEY) return undefined;
+  return hit;
+}
+
 /**
  * Map LLM extraction keys (often display names) onto configured column ids.
  * The studio table reads `rowData[columnId]` only — mismatched keys show as empty cells.
@@ -48,19 +71,13 @@ export function alignExtractedDataToColumns(
   extractedData: Record<string, string>,
   columns: ExtractionColumnDef[]
 ): Record<string, string> {
-  const byNormalizedKey = new Map<string, string>();
-  for (const [key, value] of Object.entries(extractedData)) {
-    if (isEmptyExtractionValue(value)) continue;
-    const trimmed = value.trim();
-    byNormalizedKey.set(normalizeColumnKey(key), trimmed);
-    byNormalizedKey.set(compactColumnKey(key), trimmed);
-    byNormalizedKey.set(key.toLowerCase(), trimmed);
-  }
+  const indexedKeys = indexExtractedDataByKey(extractedData);
 
   const aligned: Record<string, string> = {};
   for (const col of columns) {
     if (LITERATURE_METADATA_COLUMN_IDS.has(col.id.toLowerCase())) continue;
 
+    // Prefer exact keys (column id, then display name) before fuzzy normalized/compact matching.
     const directCandidates = [col.id, col.name, normalizeColumnKey(col.name)];
     for (const candidate of directCandidates) {
       const direct = extractedData[candidate];
@@ -71,15 +88,12 @@ export function alignExtractedDataToColumns(
     }
     if (aligned[col.id]) continue;
 
-    const idNorm = normalizeColumnKey(col.id);
-    const idCompact = compactColumnKey(col.id);
-    const nameCompact = compactColumnKey(col.name);
-    for (const [key, value] of byNormalizedKey) {
-      const keyCompact = key.replace(/_/g, "");
-      if (key === idNorm || keyCompact === idCompact || keyCompact === nameCompact) {
-        aligned[col.id] = value;
-        break;
-      }
+    const fuzzyHit =
+      lookupIndexedValue(indexedKeys, normalizeColumnKey(col.id)) ??
+      lookupIndexedValue(indexedKeys, compactColumnKey(col.id)) ??
+      lookupIndexedValue(indexedKeys, compactColumnKey(col.name));
+    if (fuzzyHit) {
+      aligned[col.id] = fuzzyHit;
     }
   }
 
@@ -87,8 +101,7 @@ export function alignExtractedDataToColumns(
 }
 
 export function columnsForExtraction<T extends ExtractionColumnDef>(columns: T[]): T[] {
-  const custom = columns.filter((c) => !LITERATURE_METADATA_COLUMN_IDS.has(c.id.toLowerCase()));
-  return custom.length > 0 ? custom : columns;
+  return columns.filter((c) => !LITERATURE_METADATA_COLUMN_IDS.has(c.id.toLowerCase()));
 }
 
 export type LiteratureReportContext = {

--- a/convex/literatureReview/workflowSteps.test.ts
+++ b/convex/literatureReview/workflowSteps.test.ts
@@ -741,13 +741,46 @@ describe("extractDataHandler with LLM extraction", () => {
 
     await extractDataHandler(mockCtx, {
       papers,
-      columns: [{ id: "title", name: "Title", isVisible: true }],
+      columns: [{ id: "study_design", name: "Study Design", isVisible: true }],
       sessionId: "test-session" as Id<"literatureReviewSessions">,
     });
 
     expect(mockCtx.runMutation).toHaveBeenCalledTimes(1);
     const callArgs = (mockCtx.runMutation as any).mock.calls[0][1];
-    // Should not have extractedData since LLM failed
+    expect(callArgs.papers[0].extractedData).toBeUndefined();
+  });
+
+  it("skips LLM extraction when columns are metadata-only", async () => {
+    vi.mocked(createLLM).mockClear();
+    (mockCtx.runQuery as any).mockResolvedValue([]);
+    (mockCtx.runMutation as any).mockResolvedValue(null);
+
+    const papers = [
+      {
+        title: "Paper One",
+        authors: ["Smith, J."],
+        year: 2023,
+        abstract: "Abstract one",
+        url: "http://example.com/1",
+        source: "arxiv" as const,
+        score: 0.9,
+        isIncluded: true,
+      },
+    ];
+
+    await extractDataHandler(mockCtx, {
+      papers,
+      columns: [
+        { id: "title", name: "Title", isVisible: true },
+        { id: "authors", name: "Authors", isVisible: true },
+        { id: "year", name: "Year", isVisible: true },
+      ],
+      sessionId: "test-session" as Id<"literatureReviewSessions">,
+    });
+
+    expect(createLLM).not.toHaveBeenCalled();
+    expect(mockCtx.runMutation).toHaveBeenCalledTimes(1);
+    const callArgs = (mockCtx.runMutation as any).mock.calls[0][1];
     expect(callArgs.papers[0].extractedData).toBeUndefined();
   });
 });

--- a/convex/literatureReview/workflowSteps.ts
+++ b/convex/literatureReview/workflowSteps.ts
@@ -57,9 +57,11 @@ import {
   compactRankedPapersForWorkflow,
 } from "./rankedPapersSnapshot.js";
 import {
+  alignExtractedDataToColumns,
   buildGroundedNumericSet,
   buildPrismaMethodsBlock,
   buildStudyCharacteristicsTable,
+  columnsForExtraction,
   getReportSectionsNeedingRegeneration,
   isTrivialReportSectionContent,
   mergeDeterministicReportSections,
@@ -608,19 +610,24 @@ async function extractPaperFieldsWithLlm(
   query: string | undefined,
   smartModel: string | undefined
 ): Promise<Record<string, string> | undefined> {
+  const extractionColumns = columnsForExtraction(columns);
+  if (extractionColumns.length === 0) {
+    return undefined;
+  }
+
   const llm = createLLM({
     apiKey: env.TOGETHER_AI_API_KEY,
-    mapModel: bulkLlmModel(),
+    mapModel: mapModelForLiteratureReview(smartModel),
     temperatures: 0.2,
-    maxTokens: 900,
-    phase: "fast",
+    maxTokens: 1_600,
+    phase: "smart",
   });
 
   const structuredLlm = llm.withStructuredOutput(ExtractDataOutputSchema, {
     name: "extract_data",
   });
 
-  const columnsText = columns
+  const columnsText = extractionColumns
     .map(
       (col) =>
         `- ${col.name} (id: ${col.id}): ${col.instructions || "Extract relevant information."}`
@@ -649,7 +656,8 @@ async function extractPaperFieldsWithLlm(
     "extractData"
   );
 
-  return response.extractedData;
+  const aligned = alignExtractedDataToColumns(response.extractedData, columns);
+  return Object.keys(aligned).length > 0 ? aligned : undefined;
 }
 
 /** One draft batch — separate action so extraction stays under Convex action limits. */
@@ -918,7 +926,7 @@ export async function generateReportHandler(
       }
     );
     const provenance = sessionContext?.workflowProvenance ?? {};
-    const columnNames = table.columns.map((c) => c.name);
+    const reportTableColumns = table.columns.map((c) => ({ id: c.id, name: c.name }));
 
     const reportPapers: ReportPaperRow[] = [];
     for (let i = 0; i < drafts.length; i++) {
@@ -940,7 +948,7 @@ export async function generateReportHandler(
 
     const sessionMetadata = JSON.stringify(provenance, null, 2);
     const methodsBlock = buildPrismaMethodsBlock(provenance);
-    const studyTable = buildStudyCharacteristicsTable(reportPapers, columnNames);
+    const studyTable = buildStudyCharacteristicsTable(reportPapers, reportTableColumns);
     logger.info("Starting report generation", {
       paperCount: drafts.length,
       sectionCount: 6,

--- a/convex/literatureReview/workflowSteps.ts
+++ b/convex/literatureReview/workflowSteps.ts
@@ -608,7 +608,8 @@ async function extractPaperFieldsWithLlm(
   },
   columns: Array<{ id: string; name: string; instructions?: string }>,
   query: string | undefined,
-  smartModel: string | undefined
+  smartModel: string | undefined,
+  logger: ReturnType<typeof createServiceLogger>
 ): Promise<Record<string, string> | undefined> {
   const extractionColumns = columnsForExtraction(columns);
   if (extractionColumns.length === 0) {
@@ -657,6 +658,13 @@ async function extractPaperFieldsWithLlm(
   );
 
   const aligned = alignExtractedDataToColumns(response.extractedData, columns);
+  if (Object.keys(aligned).length === 0 && Object.keys(response.extractedData).length > 0) {
+    logger.warn("LLM extraction returned keys that did not map to configured columns", {
+      paperTitle: paper.title,
+      llmKeys: Object.keys(response.extractedData),
+      columnIds: columns.map((c) => c.id),
+    });
+  }
   return Object.keys(aligned).length > 0 ? aligned : undefined;
 }
 
@@ -687,7 +695,8 @@ export async function extractDataBatchHandler(
           paper,
           args.columns,
           args.query,
-          args.smartModel
+          args.smartModel,
+          logger
         );
         return extractedData ? { ...paper, extractedData } : paper;
       } catch (error) {


### PR DESCRIPTION
## Summary
- Map LLM extraction keys (often display names) onto configured column ids before persisting draft rows, so studio and report tables show custom column values instead of em dashes.
- Run extraction with the review smart model, higher token budget, and custom columns only (not title/authors/year/summary).
- Resolve report characteristics table cells by both column id and name.

## Test plan
- [x] `bun run test:convex -- convex/literatureReview/reportContext.test.ts convex/literatureReview/db.test.ts convex/literatureReview/workflowSteps.test.ts`
- [ ] Run a literature review in dev and confirm Framework Name / Performance Metrics columns populate when abstracts support them

Made with [Cursor](https://cursor.com)