### PR TITLE
chore: fix Biome lint issues in convex and web

### DIFF
--- a/apps/web/src/features/notebooks/components/HomePage.tsx
+++ b/apps/web/src/features/notebooks/components/HomePage.tsx
@@ -58,7 +58,8 @@ export const HomePage: React.FC<HomePageProps> = (_props: HomePageProps) => {
   // Limit error handling
   const { handleLimitError } = useLimitErrorToast();
 
-  const deleteNotebookHandler: (id: string) => void = onDeleteNotebook ?? ((_id: string) => {});
+  const deleteNotebookHandler: (id: string) => void =
+    onDeleteNotebook ?? ((_id: string) => undefined);
 
   // Custom hooks for state and handlers
   const notebookHandlers = useNotebookHandlers({
@@ -301,7 +302,7 @@ export const HomePage: React.FC<HomePageProps> = (_props: HomePageProps) => {
               // Folder handlers
               folderActiveMenuId={folderHandlers.folderActiveMenuId}
               onOpenFolderCustomize={folderHandlers.openFolderCustomize}
-              onDeleteFolder={onDeleteFolder ?? ((_id: string) => {})}
+              onDeleteFolder={onDeleteFolder ?? ((_id: string) => undefined)}
               setFolderActiveMenuId={folderHandlers.setFolderActiveMenuId}
               // Sorting
               getSortedNotebooks={getSortedNotebooks}

--- a/apps/web/src/features/notebooks/components/views/NotebookView.tsx
+++ b/apps/web/src/features/notebooks/components/views/NotebookView.tsx
@@ -372,7 +372,7 @@ export function NotebookView() {
     return (
       <StudioPanel
         isOpen={true}
-        onClose={() => {}}
+        onClose={() => undefined}
         tools={STUDIO_TOOLS}
         width={390}
         isResizing={false}
@@ -449,7 +449,7 @@ export function NotebookView() {
             isResizing={isResizingLeft}
             userId={user?.id}
             noteId={urlNotebookId}
-            onDocumentUploaded={() => {}}
+            onDocumentUploaded={() => undefined}
             focusSourceRequest={sourceFocusRequest}
             onFocusSourceHandled={clearSourceFocusRequest}
             onDiscussTopic={handleDiscussSourceTopic}
@@ -502,12 +502,12 @@ export function NotebookView() {
             <div className="flex-1 w-full overflow-hidden">
               <SourcesPanel
                 isOpen={true}
-                onClose={() => {}}
+                onClose={() => undefined}
                 width={390}
                 isResizing={false}
                 userId={user?.id}
                 noteId={urlNotebookId}
-                onDocumentUploaded={() => {}}
+                onDocumentUploaded={() => undefined}
                 focusSourceRequest={sourceFocusRequest}
                 onFocusSourceHandled={clearSourceFocusRequest}
                 onDiscussTopic={handleDiscussSourceTopic}
@@ -520,8 +520,8 @@ export function NotebookView() {
               <ChatPanel
                 isLeftOpen={false}
                 isRightOpen={false}
-                toggleLeft={() => {}}
-                toggleRight={() => {}}
+                toggleLeft={() => undefined}
+                toggleRight={() => undefined}
                 notebookId={urlNotebookId}
                 notebookTitle={notebookTitle}
                 notebookIcon={activeNotebook?.icon}

--- a/apps/web/src/features/sources/components/AddSourceModal.tsx
+++ b/apps/web/src/features/sources/components/AddSourceModal.tsx
@@ -79,8 +79,8 @@ export const AddSourceModal: React.FC<AddSourceModalProps> = ({
   useEffect(() => {
     if (!isOpen) {
       const syntheticEvent = {
-        preventDefault: () => {},
-        stopPropagation: () => {},
+        preventDefault: () => undefined,
+        stopPropagation: () => undefined,
         currentTarget: document.createElement("div"),
         relatedTarget: null,
       } as unknown as React.DragEvent<HTMLDivElement>;

--- a/apps/web/src/features/sources/hooks/useDocumentStatus.ts
+++ b/apps/web/src/features/sources/hooks/useDocumentStatus.ts
@@ -17,6 +17,6 @@ export function useDocumentStatus(documentId: string): UseDocumentStatusResult {
     status,
     isPolling: false,
     error: null,
-    refresh: async () => {},
+    refresh: async () => undefined,
   };
 }

--- a/apps/web/src/features/studio/components/StudioPanel.tsx
+++ b/apps/web/src/features/studio/components/StudioPanel.tsx
@@ -257,8 +257,8 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
             title={miniPlayerData.title}
             transcript={miniPlayerData.transcript}
             isVisible={miniPlayerVisible}
-            onClose={onCloseMiniPlayer || (() => {})}
-            onExpand={onExpandAudioPlayer || (() => {})}
+            onClose={onCloseMiniPlayer || (() => undefined)}
+            onExpand={onExpandAudioPlayer || (() => undefined)}
           />
         )}
       </>
@@ -358,8 +358,8 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
             title={miniPlayerData.title}
             transcript={miniPlayerData.transcript}
             isVisible={miniPlayerVisible}
-            onClose={onCloseMiniPlayer || (() => {})}
-            onExpand={onExpandAudioPlayer || (() => {})}
+            onClose={onCloseMiniPlayer || (() => undefined)}
+            onExpand={onExpandAudioPlayer || (() => undefined)}
           />
         )}
       </div>

--- a/apps/web/src/features/studio/hooks/useNoteCRUD.ts
+++ b/apps/web/src/features/studio/hooks/useNoteCRUD.ts
@@ -135,9 +135,9 @@ export function useNoteCRUD({ activeNotebookId }: UseNoteCRUDProps) {
     [updateReport]
   );
 
-  const handleUpdateNoteFull = useCallback((_id: string, _note: Note) => {}, []);
+  const handleUpdateNoteFull = useCallback((_id: string, _note: Note) => undefined, []);
 
-  const handleAddNote = useCallback((_note: Note) => {}, []);
+  const handleAddNote = useCallback((_note: Note) => undefined, []);
 
   return {
     notes,

--- a/convex/_agents/mindmap/MindMapGraph.ts
+++ b/convex/_agents/mindmap/MindMapGraph.ts
@@ -56,13 +56,6 @@ export class MindMapGraph {
     });
   }
 
-  /**
-   * Typed wrapper for concept extraction
-   */
-  private async extractConcepts(content: string): Promise<ConceptExtraction> {
-    return runConceptExtraction(this.fastLlm, content);
-  }
-
   async mapProcess(state: ChunkStateType): Promise<Partial<OverallStateType> | Send> {
     const deps: MindMapMapProcessDeps = {
       extractConcepts: (c) => runConceptExtraction(this.fastLlm, c),

--- a/convex/_agents/quiz/QuizGraph.ts
+++ b/convex/_agents/quiz/QuizGraph.ts
@@ -29,7 +29,6 @@ export class QuizGraph {
   private fastLlm: ChatTogetherAI;
   private smartLlm: ChatTogetherAI;
   private fastLlmCandidateStructured: StructuredOutputInvoker<QuizCandidateResponse>;
-  private smartLlmQuestionStructured: StructuredOutputInvoker<QuizQuestion>;
   private expandLlm: ChatTogetherAI;
   private expandLlmQuestionStructured: StructuredOutputInvoker<QuizQuestion>;
 
@@ -62,11 +61,6 @@ export class QuizGraph {
       this.fastLlm,
       QuizCandidateArraySchema,
       "quiz_candidates"
-    );
-    this.smartLlmQuestionStructured = createStructuredLLM<QuizQuestion>(
-      this.smartLlm,
-      QuizQuestionSchema,
-      "quiz_question"
     );
     this.expandLlmQuestionStructured = createStructuredLLM<QuizQuestion>(
       this.expandLlm,

--- a/convex/_agents/report/ReportGraph.ts
+++ b/convex/_agents/report/ReportGraph.ts
@@ -21,14 +21,7 @@ export { packChunks, validateChunks } from "./chunkHelpers.js";
 export class ReportGraph {
   private mapModel: string;
   private smartLlm: ChatTogetherAI;
-  private maxTokens: number;
-
-  constructor(
-    apiKey: string,
-    mapModel: string,
-    reduceModel: string,
-    maxTokens: number = GRAPH_CONFIG.MAX_TOKENS
-  ) {
+  constructor(apiKey: string, mapModel: string, reduceModel: string) {
     this.mapModel = mapModel;
 
     this.smartLlm = new ChatTogetherAI({
@@ -39,8 +32,6 @@ export class ReportGraph {
       maxTokens: GRAPH_CONFIG.REDUCE_MAX_OUTPUT_TOKENS,
       modelKwargs: mergeModelKwargs(reduceModel, "smart"),
     });
-
-    this.maxTokens = maxTokens;
   }
 
   private estimateTokens(text: string): number {

--- a/convex/_agents/spreadsheet/SpreadsheetGraph.ts
+++ b/convex/_agents/spreadsheet/SpreadsheetGraph.ts
@@ -25,9 +25,7 @@ import { type ChunkProcessState, OverallState, type OverallStateType } from "./s
 export class SpreadsheetGraph {
   private fastLlm: ChatTogetherAI;
   private smartLlm: ChatTogetherAI;
-  private maxTokens: number;
-
-  constructor(apiKey: string, mapModel: string, reduceModel: string, maxTokens: number = 64000) {
+  constructor(apiKey: string, mapModel: string, reduceModel: string) {
     // Fast model for map phase (parallel text extraction)
     this.fastLlm = new ChatTogetherAI({
       apiKey,
@@ -47,8 +45,6 @@ export class SpreadsheetGraph {
       maxTokens: GRAPH_CONFIG.REDUCE_MAX_OUTPUT_TOKENS,
       modelKwargs: mergeModelKwargs(reduceModel, "smart"),
     });
-
-    this.maxTokens = maxTokens;
   }
 
   private estimateTokens(text: string): number {

--- a/convex/_lib/notebookAccess.test.ts
+++ b/convex/_lib/notebookAccess.test.ts
@@ -17,10 +17,6 @@ const modules = Object.fromEntries(
   Object.entries(rawModules).map(([key, loader]) => [key.replace(/^\/convex\//, "./"), loader])
 );
 
-function withAuth(t: ReturnType<typeof convexTest>, userId: Id<"users">) {
-  return t.withIdentity({ subject: `${userId as string}|session1` });
-}
-
 async function seedUser(t: ReturnType<typeof convexTest>): Promise<Id<"users">> {
   return t.run(async (ctx) => ctx.db.insert("users", { name: "Test" }));
 }

--- a/convex/_services/processing/TextSplitterService.ts
+++ b/convex/_services/processing/TextSplitterService.ts
@@ -18,5 +18,7 @@ export class TextSplitterService {
     return countTokens(text);
   }
 
-  static cleanup(): void {}
+  static cleanup(): void {
+    // No-op: splitter instances are stateless.
+  }
 }

--- a/convex/eval/researchEvalAction.ts
+++ b/convex/eval/researchEvalAction.ts
@@ -248,7 +248,7 @@ export const runResearchEval = action({
         );
         return loader.loadPaper(paper);
       },
-      onProgress: async () => {},
+      onProgress: async () => undefined,
     };
 
     const agent = new ResearchAgent(deps);

--- a/convex/research/workflowSteps.ts
+++ b/convex/research/workflowSteps.ts
@@ -54,7 +54,7 @@ export const planReview = internalAction({
       notebookId: args.notebookId,
       userId: args.userId,
       sourcePolicy: args.sourcePolicy,
-      onProgress: async () => {},
+      onProgress: async () => undefined,
     });
 
     const subQuestions = await agent.generatePlan(

--- a/convex/studio/infographic/prompts.ts
+++ b/convex/studio/infographic/prompts.ts
@@ -39,11 +39,6 @@ export type Infographic = z.infer<typeof InfographicSchema>;
 // CONFIGURATION
 // ============================================================
 
-const safeParseInt = (val: string | undefined, fallback: number): number => {
-  const parsed = parseInt(val || "", 10);
-  return isNaN(parsed) ? fallback : parsed;
-};
-
 export const INFOGRAPHIC_CONFIG = {
   MAX_TOKENS: 8_000,
   GENERATION_TIMEOUT_MS: 180_000,

--- a/e2e/helpers/notebook-cleanup.ts
+++ b/e2e/helpers/notebook-cleanup.ts
@@ -13,7 +13,7 @@ export async function deleteNotebookByTitleFromHome(page: Page, title: string): 
   await page
     .getByRole("button", { name: "All" })
     .click()
-    .catch(() => {});
+    .catch(() => undefined);
 
   await page
     .getByRole("heading", { name: "My Notebooks" })


### PR DESCRIPTION
## Summary
- Remove dead code flagged by Biome (unused private class members, unused helpers, unused test helper)
- Replace empty callback blocks with `undefined` returns in production paths
- Add intentional comment to `TextSplitterService.cleanup()` no-op

## Notes
959 local Biome format errors were CRLF working-copy noise on Windows; the repo already stores LF. `bun run format` normalized the working tree without git-tracked changes.

## Test plan
- [x] `bun run lint` passes locally
- [x] `bun run typecheck:convex` passes
- [x] `bun run typecheck:web` passes
- [ ] CI lint + typecheck + unit tests + build