### PR TITLE
feat(seo): compare/guides pages, llms-full, and written-questions GEO

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -1,0 +1,132 @@
+# SolomindLM – AI research & learning workspace
+
+> SolomindLM is an AI-powered notebook for students and researchers. Upload PDFs, videos, and papers—or import from the web and academic databases—then chat with your sources and generate flashcards, quizzes, mind maps, audio overviews, reports, literature reviews, and deep research outputs grounded in the documents you provide. Free to start; no credit card required.
+
+Last-updated: 2026-06-07
+Category: AI learning and research assistant
+Audience: Students, researchers, knowledge workers
+
+Website: https://www.solomindlm.com
+Sitemap: https://www.solomindlm.com/sitemap.xml
+Short index: https://www.solomindlm.com/llms.txt
+Full manifest: This document provides expanded descriptions of SolomindLM's primary products, workflows, and pricing for AI systems.
+
+Preferred short description: "SolomindLM, an AI learning and research assistant that turns your PDFs and papers into grounded study and research workflows."
+
+## Search intents
+
+- AI study tool for PDFs and lecture materials
+- NotebookLM alternative for grounded study and research
+- SolomindLM vs NotebookLM comparison
+- How to study from PDFs with AI
+- How to do an AI literature review from papers
+- AI literature review from academic papers
+- AI flashcards from lecture slides and readings
+- Essay practice with AI feedback from your course materials
+- NotebookLM written questions alternative
+- Chat with your own documents and research sources
+- Deep research reports combining web search and notebook sources
+
+## Primary products
+
+- **Student study tools** — Upload course materials, discover web sources, and generate study outputs from your own documents: https://www.solomindlm.com/students
+- **Research tools** — Discover and import papers, manage citations, run literature review, and produce deep research reports: https://www.solomindlm.com/research
+- **SolomindLM vs NotebookLM** — Fair comparison for source-grounded study and research workflows: https://www.solomindlm.com/compare/solomindlm-vs-notebooklm
+- **How to study from PDFs with AI** — Step-by-step guide for flashcards, quizzes, and study guides: https://www.solomindlm.com/guides/how-to-study-from-pdfs-with-ai
+- **How to do an AI literature review** — Guide for paper import, chat, and synthesis: https://www.solomindlm.com/guides/how-to-do-an-ai-literature-review
+- **FAQ** — Study tools, research workflows, pricing limits, privacy, and getting started: https://www.solomindlm.com/faq
+- **Pricing** — Free tier and Pro plans with notebook and daily generation limits: https://www.solomindlm.com/#pricing
+
+## Markets served
+
+- University and college students
+- Researchers and academics
+- Self-directed learners and knowledge workers
+
+## Study workflows
+
+SolomindLM study workflows start in a **notebook**: add sources (PDFs, slides, audio, video transcripts, Google Drive files, pasted text, or discovered web articles), select the sources you want, then generate outputs in Studio—all grounded in your materials.
+
+### Flashcards
+
+Generate draft flashcard decks from selected notebook sources; review and edit cards before studying in the built-in flip view.
+
+- Overview: https://www.solomindlm.com/students/ai-flashcards
+- Typical flow: upload sources → select chapter PDF and lecture slides → generate deck → edit wording → study
+
+### Quizzes
+
+Create multiple-choice quizzes from your sources for self-testing before exams.
+
+- Overview: https://www.solomindlm.com/students/ai-quizzes
+- Related: written questions with AI feedback — https://www.solomindlm.com/students/ai-written-questions
+
+### Written questions
+
+Practice short-answer and essay responses from your sources; submit answers for AI feedback. Distinct from multiple-choice Quizzes—key differentiator vs NotebookLM for written-exam prep.
+
+- Overview: https://www.solomindlm.com/students/ai-written-questions
+- Related: multiple-choice quizzes — https://www.solomindlm.com/students/ai-quizzes
+- Compare: SolomindLM vs NotebookLM (written questions with feedback) — https://www.solomindlm.com/compare/solomindlm-vs-notebooklm
+
+### Mind maps
+
+Turn dense readings into hierarchical mind maps for visual review and recall.
+
+- Overview: https://www.solomindlm.com/students/ai-mind-maps
+- Related: infographics — https://www.solomindlm.com/students/ai-infographics
+
+### Other student outputs
+
+- Upload study sources: https://www.solomindlm.com/students/upload-sources
+- Discover web sources: https://www.solomindlm.com/students/discover-sources
+- AI audio overviews: https://www.solomindlm.com/students/ai-audio-overview
+- AI reports and study guides: https://www.solomindlm.com/students/ai-reports
+- AI spreadsheets (extract tables from documents): https://www.solomindlm.com/students/ai-spreadsheets
+- Share notebooks with classmates: https://www.solomindlm.com/students/share-notebooks
+
+## Research workflows
+
+Research workflows center on **academic sources**: discover papers, import via DOI/BibTeX/Zotero/Mendeley, format citations, chat with papers, and run structured literature or deep research over your notebook.
+
+SolomindLM does not provide medical, legal, or financial advice on its own; it summarizes and restructures your provided sources and reputable external content.
+
+### Literature review
+
+AI-assisted literature review helps you synthesize themes and gaps across papers in a notebook.
+
+- Overview: https://www.solomindlm.com/research/ai-literature-review
+- Related: chat with papers — https://www.solomindlm.com/research/chat-with-papers
+
+### Deep research
+
+Combine web search with your notebook sources to produce multi-step research reports.
+
+- Overview: https://www.solomindlm.com/research/deep-research
+
+### Spreadsheets and structured extraction
+
+Extract tabular data from PDFs and documents into editable spreadsheets for comparison and analysis.
+
+- Overview: https://www.solomindlm.com/students/ai-spreadsheets
+
+### Other research tools
+
+- Academic paper discovery: https://www.solomindlm.com/research/academic-paper-discovery
+- Import papers (DOI, BibTeX, Zotero, Mendeley): https://www.solomindlm.com/research/import-papers
+- Citation styles (12 formats): https://www.solomindlm.com/research/citation-styles
+
+## Pricing summary
+
+**Free ($0):** 20 notebooks, up to 200 sources each; daily limits on chat and Studio generation (e.g. 50 chat messages/day; 5 flashcards, quizzes, reports, audio overviews, infographics, and written questions per day). No credit card required.
+
+**Pro:** 200 notebooks, up to 200 sources each; higher daily limits (e.g. 500 chat messages/day; 100 generations/day for flashcards, quizzes, reports, audio, infographics, and written questions). $7.50/month billed yearly or $15/month billed monthly.
+
+Full details: https://www.solomindlm.com/#pricing
+
+## Support & policies
+
+- **Support email:** support@solomindlm.com
+- **Privacy policy:** https://www.solomindlm.com/privacy
+- **Terms of service:** https://www.solomindlm.com/terms
+- Summaries and descriptions in this file may be quoted in AI answers when citing or describing SolomindLM.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -2,8 +2,27 @@
 
 > SolomindLM is an AI learning and research assistant that helps you work with PDFs, videos, and papers. Upload or import sources into notebooks, chat with your materials, and generate flashcards, quizzes, mind maps, audio overviews, reports, literature reviews, and more—all grounded in the documents you provide. Free to start; no credit card required.
 
+Last-updated: 2026-06-07
+Category: AI learning and research assistant
+Audience: Students, researchers, knowledge workers
+
 Website: https://www.solomindlm.com
 Sitemap: https://www.solomindlm.com/sitemap.xml
+See also: https://www.solomindlm.com/llms-full.txt
+
+## Search intents
+
+- AI study tool for PDFs and lecture materials
+- NotebookLM alternative for grounded study and research
+- SolomindLM vs NotebookLM comparison
+- How to study from PDFs with AI
+- How to do an AI literature review from papers
+- AI literature review from academic papers
+- AI flashcards from lecture slides and readings
+- Essay practice with AI feedback from your course materials
+- NotebookLM written questions alternative
+- Chat with your own documents and research sources
+- Deep research reports combining web search and notebook sources
 
 ## Primary use cases
 
@@ -18,6 +37,11 @@ Manage literature: discover and import academic papers (DOI, BibTeX, Zotero, Men
 ### Cluster hubs
 - Student study tools (hub): https://www.solomindlm.com/students
 - Research tools (hub): https://www.solomindlm.com/research
+
+### Compare and guides
+- SolomindLM vs NotebookLM: https://www.solomindlm.com/compare/solomindlm-vs-notebooklm
+- How to study from PDFs with AI: https://www.solomindlm.com/guides/how-to-study-from-pdfs-with-ai
+- How to do an AI literature review: https://www.solomindlm.com/guides/how-to-do-an-ai-literature-review
 
 ## Canonical intent pages
 
@@ -58,6 +82,7 @@ All frequently asked questions (study tools, research workflows, billing, privac
 
 - Privacy policy: https://www.solomindlm.com/privacy
 - Terms of service: https://www.solomindlm.com/terms
+- Summaries and descriptions in this file may be quoted in AI answers when citing or describing SolomindLM.
 
 ## Contact
 

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -4,6 +4,13 @@
 User-agent: *
 Allow: /
 
+# GEO / LLM helpers — explicit allow for crawler context files
+Allow: /llms.txt
+Allow: /llms-full.txt
+# https://llmstxt.org/
+# https://www.solomindlm.com/llms.txt
+# https://www.solomindlm.com/llms-full.txt
+
 # Disallow authenticated/protected routes
 Disallow: /home
 Disallow: /billing
@@ -18,7 +25,3 @@ Disallow: /api/
 
 # Sitemap reference
 Sitemap: https://www.solomindlm.com/sitemap.xml
-
-# LLM / AI crawler context
-# https://llmstxt.org/
-# https://www.solomindlm.com/llms.txt

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -22,6 +22,27 @@
   </url>
 
   <url>
+    <loc>https://www.solomindlm.com/faq</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://www.solomindlm.com/students</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://www.solomindlm.com/research</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
     <loc>https://www.solomindlm.com/students/upload-sources</loc>
     <lastmod>2026-06-07</lastmod>
     <changefreq>monthly</changefreq>
@@ -138,5 +159,26 @@
     <lastmod>2026-06-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://www.solomindlm.com/compare/solomindlm-vs-notebooklm</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://www.solomindlm.com/guides/how-to-study-from-pdfs-with-ai</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://www.solomindlm.com/guides/how-to-do-an-ai-literature-review</loc>
+    <lastmod>2026-06-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,8 @@ import { FaqPage } from "./features/landing/FaqPage";
 import { IntentLandingPage } from "./features/landing/IntentLandingPage";
 import { INTENT_LANDING_PAGES, isIntentLandingPath } from "./features/landing/intentLandingPages";
 import { LandingPage } from "./features/landing/LandingPage";
+import { SeoContentPage } from "./features/landing/SeoContentPage";
+import { isSeoContentPath, SEO_CONTENT_PAGES } from "./features/landing/seoContentPages";
 import { PrivacyPolicy } from "./features/legal/components/PrivacyPolicy";
 import { TermsOfService } from "./features/legal/components/TermsOfService";
 import { HomePage } from "./features/notebooks/components/HomePage";
@@ -163,7 +165,8 @@ const AppContent: React.FC = () => {
     location.pathname === "/sign-in" ||
     location.pathname === "/faq" ||
     isIntentLandingPath(location.pathname) ||
-    isClusterHubPath(location.pathname);
+    isClusterHubPath(location.pathname) ||
+    isSeoContentPath(location.pathname);
   const isHomePage =
     location.pathname === "/home" ||
     location.pathname === "/billing" ||
@@ -407,6 +410,14 @@ const AppContent: React.FC = () => {
                 key={page.path}
                 path={page.path}
                 element={<IntentLandingPage pagePath={page.path} />}
+              />
+            ))}
+
+            {SEO_CONTENT_PAGES.map((page) => (
+              <Route
+                key={page.path}
+                path={page.path}
+                element={<SeoContentPage pagePath={page.path} />}
               />
             ))}
 

--- a/apps/web/src/features/landing/ClusterHubLandingPage.tsx
+++ b/apps/web/src/features/landing/ClusterHubLandingPage.tsx
@@ -84,6 +84,7 @@ export function ClusterHubLandingPage({ pagePath }: ClusterHubLandingPageProps) 
         </section>
 
         <HubChildPagesSection page={page} />
+        <HubGuideLinksSection page={page} />
         <HubFaqSection
           page={page}
           openFaqIndex={openFaqIndex}
@@ -178,6 +179,50 @@ function HubChildPagesSection({ page }: { page: ClusterHubPageConfig }) {
             </div>
           );
         })}
+      </div>
+    </section>
+  );
+}
+
+function HubGuideLinksSection({ page }: { page: ClusterHubPageConfig }) {
+  if (page.guideLinks.length === 0) return null;
+
+  return (
+    <section className="px-6 md:px-8 py-16 md:py-20 border-t border-border/60">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <div className="text-center max-w-2xl mx-auto">
+          <h2 className="text-2xl md:text-3xl font-display font-bold text-foreground mb-3">
+            Guides and comparisons
+          </h2>
+          <p className="text-muted-foreground">
+            Practical workflows and tool comparisons to help you choose the right approach for{" "}
+            {page.cluster === "students"
+              ? "studying from your materials"
+              : "managing your reading list"}
+            .
+          </p>
+        </div>
+        <ul className="grid gap-4 sm:grid-cols-2 max-w-4xl mx-auto">
+          {page.guideLinks.map((link) => (
+            <li key={link.path}>
+              <Link
+                to={link.path}
+                className="group flex flex-col h-full rounded-xl border border-border bg-card p-5 hover:border-primary/40 hover:shadow-sm transition-all"
+              >
+                <span className="font-medium text-foreground group-hover:text-primary transition-colors">
+                  {link.label}
+                </span>
+                <span className="mt-2 text-sm text-muted-foreground leading-relaxed flex-1">
+                  {link.description}
+                </span>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary">
+                  Learn more
+                  <ChevronRight className="w-4 h-4" aria-hidden />
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );

--- a/apps/web/src/features/landing/SeoContentPage.tsx
+++ b/apps/web/src/features/landing/SeoContentPage.tsx
@@ -7,20 +7,19 @@ import { Button } from "@/shared/components/ui/button";
 import { SEOMeta } from "@/shared/seo/SEOMeta";
 import { isNativeShell } from "@/utils/platformDetection";
 import { Footer } from "./components/Footer";
-import {
-  getIntentBreadcrumbItems,
-  getIntentLandingPageByPath,
-  getRelatedIntentPages,
-  type IntentLandingPageConfig,
-} from "./intentLandingPages";
 import { setSignupIntent } from "./landingSignup";
+import {
+  getSeoContentBreadcrumbItems,
+  getSeoContentPageByPath,
+  type SeoContentPageConfig,
+} from "./seoContentPages";
 
-type IntentLandingPageProps = {
+type SeoContentPageProps = {
   pagePath: string;
 };
 
-export function IntentLandingPage({ pagePath }: IntentLandingPageProps) {
-  const page = getIntentLandingPageByPath(pagePath);
+export function SeoContentPage({ pagePath }: SeoContentPageProps) {
+  const page = getSeoContentPageByPath(pagePath);
   const { isAuthenticated, isLoading } = useAuth();
   const navigate = useNavigate();
   const [authModalOpen, setAuthModalOpen] = useState(false);
@@ -38,7 +37,7 @@ export function IntentLandingPage({ pagePath }: IntentLandingPageProps) {
   }
 
   const openSignup = () => {
-    setSignupIntent(page.intentKey);
+    setSignupIntent(page.signupIntentKey);
     setAuthModalOpen(true);
   };
 
@@ -49,17 +48,19 @@ export function IntentLandingPage({ pagePath }: IntentLandingPageProps) {
         title={page.title}
         description={page.description}
         keywords={page.keywords}
+        ogType="article"
       />
       <div className="min-h-screen landing-grid-pattern">
-        <IntentHeader />
-        <IntentHero page={page} onSignup={openSignup} />
-        <IntentFaqSection
+        <SeoContentHeader />
+        <SeoContentHero page={page} onSignup={openSignup} />
+        <SeoContentBody page={page} />
+        <SeoContentFaqSection
           page={page}
           openFaqIndex={openFaqIndex}
           onToggleFaq={(index) => setOpenFaqIndex(openFaqIndex === index ? null : index)}
         />
-        <IntentRelatedFeaturesSection page={page} />
-        <IntentFinalCta page={page} onSignup={openSignup} />
+        <SeoContentRelatedSection page={page} />
+        <SeoContentFinalCta page={page} onSignup={openSignup} />
         <Footer />
       </div>
       <AuthModal
@@ -71,7 +72,7 @@ export function IntentLandingPage({ pagePath }: IntentLandingPageProps) {
   );
 }
 
-function IntentHeader() {
+function SeoContentHeader() {
   return (
     <header className="border-b border-border/60 bg-card/40 backdrop-blur-sm sticky top-0 z-50">
       <div className="max-w-[1500px] mx-auto px-6 sm:px-8 lg:px-12 h-16 flex items-center justify-between">
@@ -96,82 +97,121 @@ function IntentHeader() {
   );
 }
 
-function IntentHero({ page, onSignup }: { page: IntentLandingPageConfig; onSignup: () => void }) {
-  const breadcrumbItems = getIntentBreadcrumbItems(page);
+function SeoContentHero({ page, onSignup }: { page: SeoContentPageConfig; onSignup: () => void }) {
+  const breadcrumbItems = getSeoContentBreadcrumbItems(page);
 
   return (
-    <section className="px-6 md:px-8 pt-16 pb-20 md:pt-24 md:pb-28">
-      <div className="max-w-5xl mx-auto space-y-12">
-        <div className="max-w-3xl mx-auto text-center space-y-8">
-          <IntentBreadcrumb items={breadcrumbItems} />
-          <h1 className="text-4xl md:text-5xl font-display font-bold text-foreground tracking-tight leading-tight">
-            {page.h1}
-          </h1>
-          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-            {page.subheadline}
-          </p>
-          {page.heroCrossLink ? (
-            <div className="rounded-xl border border-primary/25 bg-primary/5 p-5 text-left max-w-xl mx-auto">
-              <p className="text-sm font-semibold text-foreground mb-1">
-                {page.heroCrossLink.label}
+    <section className="px-6 md:px-8 pt-16 pb-12 md:pt-24 md:pb-16">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <SeoContentBreadcrumb items={breadcrumbItems} />
+        <h1 className="text-4xl md:text-5xl font-display font-bold text-foreground tracking-tight leading-tight text-center">
+          {page.h1}
+        </h1>
+        <p className="text-lg md:text-xl text-muted-foreground leading-relaxed text-center">
+          {page.intro}
+        </p>
+        {page.quickAnswer ? (
+          <div className="rounded-xl border border-border bg-card p-6 md:p-8 space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Quick answer
+            </p>
+            {page.quickAnswer.chooseCompetitor ? (
+              <p className="text-sm text-foreground leading-relaxed">
+                <span className="font-medium">NotebookLM:</span> {page.quickAnswer.chooseCompetitor}
               </p>
-              <p className="text-sm text-muted-foreground leading-relaxed mb-3">
-                {page.heroCrossLink.description}
-              </p>
-              <Link
-                to={page.heroCrossLink.path}
-                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-              >
-                Written questions with feedback
-                <ChevronRight className="w-4 h-4" aria-hidden />
-              </Link>
-            </div>
-          ) : null}
+            ) : null}
+            <p className="text-sm text-foreground leading-relaxed">
+              <span className="font-medium">SolomindLM:</span> {page.quickAnswer.chooseSolomindlm}
+            </p>
+          </div>
+        ) : null}
+        <div className="flex justify-center">
           <Button size="lg" onClick={onSignup} className="font-semibold px-8">
             {page.ctaLabel}
           </Button>
-        </div>
-
-        {page.proofBullets.length > 0 ? (
-          <div className="grid gap-4 sm:grid-cols-3">
-            {page.proofBullets.map((bullet, index) => (
-              <div
-                key={bullet}
-                className="rounded-xl border border-border bg-card/80 p-6 shadow-sm"
-              >
-                <p className="text-xs font-mono text-muted-foreground mb-2">
-                  {String(index + 1).padStart(2, "0")}
-                </p>
-                <p className="text-sm text-foreground leading-relaxed">{bullet}</p>
-              </div>
-            ))}
-          </div>
-        ) : null}
-
-        <div className="rounded-xl border border-border bg-card p-6 md:p-8">
-          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-4">
-            Example workflow
-          </p>
-          <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-center">
-            <div className="rounded-lg bg-secondary/40 p-4">
-              <p className="text-xs text-muted-foreground mb-1">Source</p>
-              <p className="text-sm font-medium text-foreground">{page.sourceToOutput.source}</p>
-            </div>
-            <p className="text-center text-muted-foreground hidden md:block" aria-hidden>
-              →
-            </p>
-            <div className="rounded-lg bg-secondary/40 p-4">
-              <p className="text-xs text-muted-foreground mb-1">Output</p>
-              <p className="text-sm font-medium text-foreground">{page.sourceToOutput.output}</p>
-            </div>
-          </div>
         </div>
       </div>
     </section>
   );
 }
 
-function IntentBreadcrumb({ items }: { items: ReturnType<typeof getIntentBreadcrumbItems> }) {
+function SeoContentBody({ page }: { page: SeoContentPageConfig }) {
+  return (
+    <section className="px-6 md:px-8 pb-16 md:pb-20">
+      <div className="max-w-3xl mx-auto space-y-12">
+        {page.comparisonTable ? <SeoContentComparisonTable rows={page.comparisonTable} /> : null}
+        {page.sections.map((section) => (
+          <article key={section.h2} className="space-y-4">
+            <h2 className="text-2xl md:text-3xl font-display font-bold text-foreground">
+              {section.h2}
+            </h2>
+            {section.paragraphs.map((paragraph) => (
+              <p key={paragraph} className="text-muted-foreground leading-relaxed">
+                {paragraph}
+              </p>
+            ))}
+            {section.bullets && section.bullets.length > 0 ? (
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                {section.bullets.map((bullet) => (
+                  <li key={bullet} className="leading-relaxed">
+                    {bullet}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SeoContentComparisonTable({
+  rows,
+}: {
+  rows: NonNullable<SeoContentPageConfig["comparisonTable"]>;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border bg-card">
+      <table className="w-full min-w-[640px] text-sm bg-card">
+        <thead>
+          <tr className="border-b border-border bg-muted">
+            <th scope="col" className="px-4 py-3 text-left font-semibold text-foreground">
+              Topic
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-semibold text-foreground">
+              SolomindLM
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-semibold text-foreground">
+              NotebookLM
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.topic} className="border-b border-border/60 last:border-0">
+              <th scope="row" className="px-4 py-3 text-left font-medium text-foreground align-top">
+                {row.topic}
+              </th>
+              <td className="px-4 py-3 text-muted-foreground align-top leading-relaxed">
+                {row.solomindlm}
+              </td>
+              <td className="px-4 py-3 text-muted-foreground align-top leading-relaxed">
+                {row.competitor}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SeoContentBreadcrumb({
+  items,
+}: {
+  items: ReturnType<typeof getSeoContentBreadcrumbItems>;
+}) {
   return (
     <nav aria-label="Breadcrumb" className="flex justify-center">
       <ol className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
@@ -199,34 +239,32 @@ function IntentBreadcrumb({ items }: { items: ReturnType<typeof getIntentBreadcr
   );
 }
 
-function IntentRelatedFeaturesSection({ page }: { page: IntentLandingPageConfig }) {
-  const relatedPages = getRelatedIntentPages(page);
-  if (relatedPages.length === 0) return null;
+function SeoContentRelatedSection({ page }: { page: SeoContentPageConfig }) {
+  if (page.relatedLinks.length === 0) return null;
 
   return (
     <section className="px-6 md:px-8 py-16 md:py-20 border-t border-border/60 bg-card/30">
       <div className="max-w-5xl mx-auto space-y-8">
         <div className="text-center max-w-2xl mx-auto">
           <h2 className="text-2xl md:text-3xl font-display font-bold text-foreground mb-3">
-            Related features
+            Related pages
           </h2>
           <p className="text-muted-foreground">
-            Explore other {page.cluster === "students" ? "study" : "research"} workflows in
-            SolomindLM.
+            Continue with SolomindLM study and research workflows.
           </p>
         </div>
         <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {relatedPages.map((relatedPage) => (
-            <li key={relatedPage.path}>
+          {page.relatedLinks.map((link) => (
+            <li key={link.path}>
               <Link
-                to={relatedPage.path}
+                to={link.path}
                 className="group flex flex-col h-full rounded-xl border border-border bg-card p-5 hover:border-primary/40 hover:shadow-sm transition-all"
               >
                 <span className="font-medium text-foreground group-hover:text-primary transition-colors">
-                  {relatedPage.navLabel}
+                  {link.label}
                 </span>
                 <span className="mt-2 text-sm text-muted-foreground leading-relaxed flex-1">
-                  {relatedPage.subheadline}
+                  {link.description}
                 </span>
                 <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-primary">
                   Learn more
@@ -241,12 +279,12 @@ function IntentRelatedFeaturesSection({ page }: { page: IntentLandingPageConfig 
   );
 }
 
-function IntentFaqSection({
+function SeoContentFaqSection({
   page,
   openFaqIndex,
   onToggleFaq,
 }: {
-  page: IntentLandingPageConfig;
+  page: SeoContentPageConfig;
   openFaqIndex: number | null;
   onToggleFaq: (index: number) => void;
 }) {
@@ -293,11 +331,11 @@ function IntentFaqSection({
   );
 }
 
-function IntentFinalCta({
+function SeoContentFinalCta({
   page,
   onSignup,
 }: {
-  page: IntentLandingPageConfig;
+  page: SeoContentPageConfig;
   onSignup: () => void;
 }) {
   return (

--- a/apps/web/src/features/landing/clusterHubPages.ts
+++ b/apps/web/src/features/landing/clusterHubPages.ts
@@ -5,6 +5,12 @@ import {
   type IntentLandingPageConfig,
 } from "./intentLandingPages";
 
+export type ClusterHubGuideLink = {
+  path: string;
+  label: string;
+  description: string;
+};
+
 export type ClusterHubSection = {
   title: string;
   description: string;
@@ -21,6 +27,7 @@ export type ClusterHubPageConfig = {
   subheadline: string;
   summaryBullets: string[];
   sections: ClusterHubSection[];
+  guideLinks: ClusterHubGuideLink[];
   faqs: FAQItem[];
   ctaLabel: string;
   conversionPromise: string;
@@ -67,6 +74,26 @@ export const CLUSTER_HUB_PAGES: ClusterHubPageConfig[] = [
           "writtenQuestions",
           "spreadsheets",
         ],
+      },
+    ],
+    guideLinks: [
+      {
+        path: "/students/ai-written-questions",
+        label: "Written questions with feedback",
+        description:
+          "Practice short-answer and essay responses from your course material—distinct from multiple-choice quizzes.",
+      },
+      {
+        path: "/guides/how-to-study-from-pdfs-with-ai",
+        label: "How to study from PDFs with AI",
+        description:
+          "Step-by-step workflow for turning readings and lecture slides into flashcards, quizzes, mind maps, and study guides.",
+      },
+      {
+        path: "/compare/solomindlm-vs-notebooklm",
+        label: "SolomindLM vs NotebookLM",
+        description:
+          "Fair comparison of source-grounded study tools—outputs, pricing, and which workflow fits your classes.",
       },
     ],
     faqs: [
@@ -126,6 +153,20 @@ export const CLUSTER_HUB_PAGES: ClusterHubPageConfig[] = [
         description:
           "Work with your collection through chat, literature review, deep research, and citation formatting.",
         intentKeys: ["literatureReview", "chat", "deepResearch", "citationStyles"],
+      },
+    ],
+    guideLinks: [
+      {
+        path: "/guides/how-to-do-an-ai-literature-review",
+        label: "How to do an AI literature review",
+        description:
+          "Build a paper set, chat across sources, run literature review mode, and format citations.",
+      },
+      {
+        path: "/compare/solomindlm-vs-notebooklm",
+        label: "SolomindLM vs NotebookLM",
+        description:
+          "Compare academic import, literature review, and research outputs before you choose a notebook tool.",
       },
     ],
     faqs: [

--- a/apps/web/src/features/landing/components/FeaturesGrid.tsx
+++ b/apps/web/src/features/landing/components/FeaturesGrid.tsx
@@ -18,6 +18,7 @@ import { Link } from "react-router-dom";
 import {
   FEATURES_MARQUEE_ROW_1_ORDER,
   FEATURES_MARQUEE_ROW_2_ORDER,
+  getLandingFeatureColor,
   LANDING_CONTENT,
   orderLandingFeatures,
 } from "../constants";
@@ -55,40 +56,9 @@ export const FeaturesGrid: React.FC = () => {
     }
   };
 
-  const getColorForFeature = (id: string) => {
-    switch (id) {
-      case "rag":
-        return "text-violet-600";
-      case "chat":
-        return "text-sky-700";
-      case "deepResearch":
-        return "text-indigo-700";
-      case "literatureReview":
-        return "text-blue-700";
-      case "audio":
-        return "text-purple-700";
-      case "mindmap":
-        return "text-fuchsia-600";
-      case "reports":
-        return "text-amber-600";
-      case "flashcards":
-        return "text-red-700";
-      case "quiz":
-        return "text-blue-700";
-      case "infographic":
-        return "text-violet-600";
-      case "writtenQuestions":
-        return "text-green-700";
-      case "spreadsheets":
-        return "text-cyan-600";
-      default:
-        return "text-primary";
-    }
-  };
-
   const renderCard = (feature: (typeof LANDING_CONTENT.features)[0]) => {
     const Icon = getIconForFeature(feature.id);
-    const colorClass = getColorForFeature(feature.id);
+    const colorClass = getLandingFeatureColor(feature.id);
     const intentPath = FEATURE_INTENT_PATHS[feature.id];
     return (
       <div

--- a/apps/web/src/features/landing/components/Footer.tsx
+++ b/apps/web/src/features/landing/components/Footer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { getIntentPagesByCluster } from "../intentLandingPages";
+import { getComparisonPages } from "../seoContentPages";
 
 const FOOTER_TAGLINE =
   "SolomindLM is an AI learning and research assistant that helps you work with PDFs, videos, and papers—flashcards, quizzes, reports, chat, and more, starting from the material you upload.";
@@ -81,12 +82,13 @@ export const Footer: React.FC = () => {
   const currentYear = new Date().getFullYear();
   const studentPages = getIntentPagesByCluster("students");
   const researchPages = getIntentPagesByCluster("research");
+  const comparisonPages = getComparisonPages();
 
   return (
     <footer className="border-t border-border/60 bg-card/40">
       <div className="max-w-[1500px] w-full mx-auto px-6 sm:px-8 lg:px-12 pt-16 pb-10">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-12 lg:gap-10">
-          <div className="sm:col-span-2 lg:col-span-4">
+          <div className="sm:col-span-2 lg:col-span-3">
             <Link to="/" className="inline-flex items-center gap-2.5 mb-5">
               <img
                 src="/SolomindLM_logo.png"
@@ -141,10 +143,20 @@ export const Footer: React.FC = () => {
             </FooterLinkColumn>
           </div>
 
-          <div className="lg:col-span-3">
+          <div className="lg:col-span-2">
             <FooterLinkColumn title="For Students">
               <FooterLink to="/students">All student tools</FooterLink>
               {studentPages.map((page) => (
+                <FooterLink key={page.path} to={page.path}>
+                  {page.navLabel}
+                </FooterLink>
+              ))}
+            </FooterLinkColumn>
+          </div>
+
+          <div className="lg:col-span-2">
+            <FooterLinkColumn title="Comparisons">
+              {comparisonPages.map((page) => (
                 <FooterLink key={page.path} to={page.path}>
                   {page.navLabel}
                 </FooterLink>

--- a/apps/web/src/features/landing/constants.ts
+++ b/apps/web/src/features/landing/constants.ts
@@ -12,15 +12,23 @@ const LANDING_CHAT_TOOLS = [
     id: "literatureReview",
     label: "Literature Review",
     iconName: "FileText",
-    color: "text-blue-700",
+    color: "text-orange-600",
   },
 ] as const;
 
 const LANDING_TOOLS = [
-  { id: "rag", label: "Grounded RAG System", iconName: "Brain", color: "text-violet-600" },
+  { id: "rag", label: "Grounded RAG System", iconName: "Brain", color: "text-purple-700" },
   ...LANDING_CHAT_TOOLS,
   ...STUDIO_TOOLS,
 ];
+
+const LANDING_FEATURE_COLOR_BY_ID = new Map(
+  LANDING_TOOLS.map((tool) => [tool.id, tool.color] as const)
+);
+
+export function getLandingFeatureColor(id: string): string {
+  return LANDING_FEATURE_COLOR_BY_ID.get(id) ?? "text-primary";
+}
 
 export const LANDING_CONTENT = {
   hero: {

--- a/apps/web/src/features/landing/intentLandingPages.ts
+++ b/apps/web/src/features/landing/intentLandingPages.ts
@@ -14,6 +14,8 @@ export type IntentLandingPageConfig = {
   conversionPromise: string;
   proofBullets: string[];
   sourceToOutput: { source: string; output: string };
+  /** Prominent hero cross-link to a related intent page (e.g. quizzes → written questions). */
+  heroCrossLink?: { path: string; label: string; description: string };
   faqs: FAQItem[];
   ctaLabel: string;
   navLabel: string;
@@ -232,7 +234,13 @@ export const INTENT_LANDING_PAGES: IntentLandingPageConfig[] = [
     keywords: "AI quiz, multiple choice, practice test, exam prep, study quiz",
     h1: "Multiple-choice quizzes from your study materials",
     subheadline:
-      "Generate practice quizzes with configurable count, difficulty, and topic focus—all multiple-choice, distinct from written-response practice.",
+      "Generate practice quizzes with configurable count, difficulty, and topic focus—all multiple-choice. For essay or short-answer exams, use Written Questions instead.",
+    heroCrossLink: {
+      path: "/students/ai-written-questions",
+      label: "Practicing for essay or short-answer exams?",
+      description:
+        "Written Questions generates prompts from your sources and gives AI feedback on responses you submit—not multiple choice.",
+    },
     conversionPromise: "Start free and build a practice quiz from your next reading assignment.",
     proofBullets: [
       "Multiple-choice questions only",

--- a/apps/web/src/features/landing/seoContentPages.test.ts
+++ b/apps/web/src/features/landing/seoContentPages.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  getComparisonPages,
+  getSeoContentBreadcrumbItems,
+  getSeoContentPageByPath,
+  getSeoContentPaths,
+  SEO_CONTENT_PAGES,
+} from "./seoContentPages";
+
+describe("SEO_CONTENT_PAGES", () => {
+  it("registers the three programmatic SEO pages at expected paths", () => {
+    expect(getSeoContentPaths()).toEqual([
+      "/compare/solomindlm-vs-notebooklm",
+      "/guides/how-to-study-from-pdfs-with-ai",
+      "/guides/how-to-do-an-ai-literature-review",
+    ]);
+    expect(SEO_CONTENT_PAGES).toHaveLength(3);
+  });
+});
+
+describe("getComparisonPages", () => {
+  it("returns only compare-type SEO content pages", () => {
+    const pages = getComparisonPages();
+    expect(pages).toHaveLength(1);
+    expect(pages[0]?.path).toBe("/compare/solomindlm-vs-notebooklm");
+    expect(pages.every((page) => page.pageType === "compare")).toBe(true);
+  });
+});
+
+describe("getSeoContentBreadcrumbItems", () => {
+  it("returns Home → Compare → page for comparison content", () => {
+    const page = getSeoContentPageByPath("/compare/solomindlm-vs-notebooklm");
+    expect(page).toBeDefined();
+
+    expect(getSeoContentBreadcrumbItems(page!)).toEqual([
+      { name: "Home", path: "/" },
+      { name: "Compare", path: "/compare/solomindlm-vs-notebooklm" },
+      { name: "SolomindLM vs NotebookLM", path: "/compare/solomindlm-vs-notebooklm" },
+    ]);
+  });
+
+  it("returns Home → Guides → page for guide content", () => {
+    const page = getSeoContentPageByPath("/guides/how-to-do-an-ai-literature-review");
+    expect(page).toBeDefined();
+
+    expect(getSeoContentBreadcrumbItems(page!)).toEqual([
+      { name: "Home", path: "/" },
+      { name: "Guides", path: "/guides/how-to-study-from-pdfs-with-ai" },
+      { name: "AI literature review guide", path: "/guides/how-to-do-an-ai-literature-review" },
+    ]);
+  });
+});
+
+describe("compare page content", () => {
+  it("includes a comparison table and quick answer", () => {
+    const page = getSeoContentPageByPath("/compare/solomindlm-vs-notebooklm");
+    expect(page?.comparisonTable?.length).toBeGreaterThan(0);
+    expect(page?.quickAnswer?.chooseSolomindlm).toBeTruthy();
+    expect(page?.quickAnswer?.chooseCompetitor).toBeTruthy();
+    expect(page?.faqs.some((faq) => faq.question.includes("NotebookLM alternative"))).toBe(true);
+  });
+});

--- a/apps/web/src/features/landing/seoContentPages.ts
+++ b/apps/web/src/features/landing/seoContentPages.ts
@@ -1,0 +1,570 @@
+import type { FAQItem } from "./constants";
+
+export const SEO_CONTENT_LAST_UPDATED = "2026-06-07";
+
+export type SeoContentPageType = "compare" | "guide";
+
+export type SeoContentSection = {
+  h2: string;
+  paragraphs: string[];
+  bullets?: string[];
+};
+
+export type SeoContentComparisonRow = {
+  topic: string;
+  solomindlm: string;
+  competitor: string;
+};
+
+export type SeoContentQuickAnswer = {
+  chooseSolomindlm: string;
+  chooseCompetitor?: string;
+};
+
+export type SeoContentRelatedLink = {
+  path: string;
+  label: string;
+  description: string;
+};
+
+export type SeoContentPageConfig = {
+  path: string;
+  pageType: SeoContentPageType;
+  title: string;
+  description: string;
+  keywords: string;
+  h1: string;
+  intro: string;
+  quickAnswer?: SeoContentQuickAnswer;
+  comparisonTable?: SeoContentComparisonRow[];
+  sections: SeoContentSection[];
+  faqs: FAQItem[];
+  ctaLabel: string;
+  conversionPromise: string;
+  signupIntentKey: string;
+  breadcrumbParent: { name: string; path: string };
+  navLabel: string;
+  relatedLinks: SeoContentRelatedLink[];
+  articleType: "Article" | "TechArticle";
+  changefreq?: "weekly" | "monthly";
+  priority?: number;
+};
+
+export const SEO_CONTENT_PAGES: SeoContentPageConfig[] = [
+  {
+    path: "/compare/solomindlm-vs-notebooklm",
+    pageType: "compare",
+    title: "SolomindLM vs NotebookLM: Which AI Research and Study Tool Fits Your Workflow?",
+    description:
+      "Compare SolomindLM and NotebookLM for studying from PDFs, source-grounded chat, flashcards, quizzes, literature review, and deep research workflows.",
+    keywords:
+      "SolomindLM vs NotebookLM, NotebookLM alternative, best AI study tool for PDFs, AI research tool flashcards literature review",
+    h1: "SolomindLM vs NotebookLM",
+    intro:
+      "SolomindLM and NotebookLM both deliver strong source-grounded chat with citations and synthesis from your own materials—not general web AI alone. NotebookLM leans into Google's ecosystem and study features such as Audio Overviews, Video Overviews, and the Learning Guide. SolomindLM differentiates with notebook folders, web and academic discovery, literature review with twelve citation styles, chat search across external sources, multiple model choices, and study tools such as written questions with feedback and spaced-repetition flashcards.",
+    quickAnswer: {
+      chooseCompetitor:
+        "Choose NotebookLM if you want Google's ecosystem integration plus Audio Overviews, Video Overviews, flashcards, quizzes, reports, and the Learning Guide AI tutor on top of source-grounded chat with citations.",
+      chooseSolomindlm:
+        "Choose SolomindLM if you want source-grounded chat with citations plus folders for notebooks, web and academic source discovery, literature review with twelve citation styles, chat search with one-click save to your notebook, a model switcher, voice input in chat, audio transcription, written questions with feedback, spaced-repetition flashcards, editable reports, and academic import workflows.",
+    },
+    comparisonTable: [
+      {
+        topic: "Source-grounded chat",
+        solomindlm:
+          "Source-grounded chat with citations across notebook sources; RAG-backed answers and Studio outputs synthesized from your uploads.",
+        competitor:
+          "Source-grounded chat with citations against uploaded sources; synthesis and study outputs from the same materials.",
+      },
+      {
+        topic: "Student outputs",
+        solomindlm:
+          "Flashcards with spaced repetition, quizzes, mind maps, audio overviews, editable reports, infographics, spreadsheets.",
+        competitor:
+          "Audio Overviews, Video Overviews, flashcards, quizzes, mind maps, reports, infographics, Learning Guide.",
+      },
+      {
+        topic: "Written questions",
+        solomindlm:
+          "Short-answer and essay prompts from your sources with AI feedback on responses you submit—not multiple-choice only.",
+        competitor:
+          "Quizzes and the Learning Guide AI tutor; no written-response practice with feedback on product pages.",
+      },
+      {
+        topic: "Research workflows",
+        solomindlm:
+          "Academic paper discovery, import papers, AI literature review, deep research, and formatted citations in multiple styles.",
+        competitor:
+          "Source discovery, Deep Research, and literature review synthesis on its plans and product pages.",
+      },
+      {
+        topic: "Literature review citations",
+        solomindlm:
+          "Twelve citation styles—including APA, MLA, Chicago, IEEE, Vancouver, and Harvard—for literature reviews, reports, and the Cite Paper modal.",
+        competitor:
+          "No multi-style academic citation formatting for literature review outputs described on product pages.",
+      },
+      {
+        topic: "Notebook organization",
+        solomindlm: "Organize notebooks in folders and move them between folders.",
+        competitor: "No equivalent folder organization described on official product pages.",
+      },
+      {
+        topic: "Source discovery",
+        solomindlm:
+          "Built-in web and academic discovery with results you can add directly to notebooks.",
+        competitor:
+          "Emphasizes uploads and plan-tier source discovery rather than the same web plus academic discovery workflow.",
+      },
+      {
+        topic: "Chat search & models",
+        solomindlm:
+          "Optional web and academic search in chat; save external hits to the notebook; multiple model choices; voice transcription in chat.",
+        competitor:
+          "Google's model stack only; no model switcher, in-chat web/academic search, or voice input called out on product pages.",
+      },
+      {
+        topic: "Audio & source panel",
+        solomindlm:
+          "Upload audio for transcription; delete and refresh sources from the source panel.",
+        competitor:
+          "No audio ingestion or source-panel delete and refresh workflow described on product pages.",
+      },
+      {
+        topic: "Academic import",
+        solomindlm: "DOI, BibTeX, Zotero, and Mendeley import into research notebooks.",
+        competitor:
+          "Official pages emphasize uploads and source discovery rather than academic reference-manager imports.",
+      },
+      {
+        topic: "Pricing model",
+        solomindlm:
+          "Free ($0): 5 notebooks, 200 sources per notebook, daily generation caps. Pro ($7.50/mo billed yearly or $15/mo monthly): 100 notebooks, 200 sources per notebook, higher daily limits.",
+        competitor:
+          "Free, Plus, Pro, and Ultra tiers; source limits of 50, 100, 300, and 600 per notebook respectively.",
+      },
+      {
+        topic: "Best fit",
+        solomindlm:
+          "Students and researchers who want grounded synthesis with citations plus folders, discovery, and academic workflows.",
+        competitor:
+          "Users anchored in Google Workspace who want Google's study features on top of grounded chat.",
+      },
+    ],
+    sections: [
+      {
+        h2: "What do SolomindLM and NotebookLM have in common?",
+        paragraphs: [
+          "Both tools are built around source-grounded AI with citations: you add documents, ask questions, and get answers and outputs that refer back to those materials rather than inventing facts from general training data alone.",
+          "Each supports study-oriented outputs such as flashcards, quizzes, mind maps, audio-style recaps, reports, and infographics. Both are useful when you need to review course readings or research papers inside a dedicated workspace instead of copying text into a blank chat window.",
+        ],
+      },
+      {
+        h2: "When is SolomindLM the better choice?",
+        paragraphs: [
+          "SolomindLM fits when your workflow needs more than upload-and-chat inside one Google stack. It combines notebook folders, built-in discovery, flexible chat search, and study and research tools that NotebookLM does not emphasize on its product pages.",
+        ],
+        bullets: [
+          "You want notebooks organized in folders and moved between them",
+          "You need web or academic discovery with one-click add to a notebook",
+          "You want web or academic search in chat and to save external sources from chat into the notebook",
+          "You prefer choosing among multiple models instead of a single Google model stack",
+          "You need voice transcription in chat or audio file ingestion with transcription",
+          "You want written questions with feedback on your answers—a standout SolomindLM feature",
+          "You want flashcards with a spaced-repetition study mode",
+          "You need to edit generated reports in place",
+          "You want delete and refresh controls in the source panel",
+          "You need DOI, BibTeX, Zotero, or Mendeley imports for a reading list",
+          "You need literature review outputs with references formatted in APA, MLA, Chicago, IEEE, Vancouver, Harvard, or other academic styles",
+        ],
+      },
+      {
+        h2: "What sets SolomindLM apart?",
+        paragraphs: [
+          "Both products generate flashcards, quizzes, mind maps, reports, infographics, and spreadsheets from sources. The meaningful differences are workflow depth and control—not a longer list of output types.",
+        ],
+        bullets: [
+          "Notebook folders: group notebooks and move them between folders",
+          "Written questions with feedback on short and essay answers",
+          "Flashcards with spaced-repetition review",
+          "Editable reports after generation",
+          "Web and academic source discovery built into the app",
+          "Web and academic search in chat, with external sources easy to add to the notebook",
+          "Model switcher across multiple models",
+          "Voice transcription in chat and audio source ingestion",
+          "Delete and refresh options in the source panel",
+          "Academic import via DOI, BibTeX, Zotero, and Mendeley",
+          "Twelve citation styles for literature reviews and reports (APA, MLA, Chicago, IEEE, Vancouver, Harvard, and more)",
+        ],
+      },
+      {
+        h2: "When is NotebookLM the better choice?",
+        paragraphs: [
+          "NotebookLM is a strong fit when you already live in Google Workspace, want polished source-grounded chat with citations, and plan to use Google's study features such as Audio Overviews, Video Overviews, and the Learning Guide—a personal AI tutor that uses probing questions and adapts explanations to your learning style—on supported plans.",
+          "If your workflow is mostly upload → chat → generate study aids inside Google's ecosystem, NotebookLM's integration advantages may outweigh a separate notebook product.",
+        ],
+      },
+      {
+        h2: "Which tool is better for students?",
+        paragraphs: [
+          "For students, the better tool depends on scope. Both offer strong grounded chat with citations from uploads. NotebookLM adds Video Overviews and the Learning Guide AI tutor on supported plans. SolomindLM differentiates with written questions with feedback, spaced-repetition flashcards, notebook folders, in-app discovery, chat search that saves sources to your notebook, voice input, and editable reports.",
+          "Neither replaces reviewing your original PDFs before exams. Pick the tool whose outputs match how you actually study.",
+        ],
+      },
+      {
+        h2: "Which tool is better for literature review?",
+        paragraphs: [
+          "SolomindLM is designed for research notebooks with academic discovery, paper import, chat across papers, and dedicated literature review mode—with twelve citation styles (APA, MLA, Chicago, IEEE, Vancouver, Harvard, and more) for formatted references in reviews and reports. NotebookLM offers source discovery, Deep Research, and literature review synthesis, but does not offer the same multi-style citation formatting for literature review deliverables.",
+          "For a reading-list-first literature review where you need import, synthesis, and field-appropriate citations, SolomindLM is the closer match. For exploratory synthesis from mixed uploads inside Google, NotebookLM remains competitive.",
+        ],
+      },
+      {
+        h2: "Which tool is better for studying from PDFs?",
+        paragraphs: [
+          "Both handle PDF-grounded study well. Upload chapters or lecture slides, ask clarifying questions, then generate flashcards or quizzes. Each can also produce mind maps, audio recaps, reports, and infographics from the same sources.",
+          "NotebookLM adds Video Overviews and the Learning Guide AI tutor on supported plans. SolomindLM adds written questions with feedback, spaced-repetition flashcards, voice and audio ingestion, discovery and chat search workflows, and editable reports—pick based on control and workflow fit, not on who lists more output types.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Is SolomindLM a NotebookLM alternative?",
+        answer:
+          "Yes, for many workflows. Both support source-grounded chat with citations. SolomindLM is the stronger fit when you also need folders, web and academic discovery, chat search with save-to-notebook, multiple models, written questions with feedback, spaced-repetition flashcards, editable reports, and academic imports. NotebookLM remains the better fit if you prioritize Google's ecosystem, Video Overviews, and the Learning Guide AI tutor.",
+      },
+      {
+        question: "Which tool is better for students?",
+        answer:
+          "Both handle grounded chat with citations well. NotebookLM adds Video Overviews and the Learning Guide AI tutor on supported plans. SolomindLM fits students who want written questions with feedback, spaced-repetition flashcards, discovery and chat search workflows, voice input, notebook folders, and editable reports. Compare workflows against how you actually study—not just output checklists.",
+      },
+      {
+        question: "Which tool is better for literature review?",
+        answer:
+          "SolomindLM is built for research notebooks with paper discovery, DOI and reference-manager import, AI literature review, and twelve citation styles for formatted references in reviews and reports. NotebookLM supports discovery, Deep Research, and literature review synthesis but does not offer the same multi-style citation formatting or academic import workflow.",
+      },
+      {
+        question: "Does NotebookLM have written questions with feedback?",
+        answer:
+          "NotebookLM offers quizzes and the Learning Guide AI tutor, but its product pages do not describe short-answer or essay practice with feedback on your written responses. SolomindLM's Written Questions tool generates prompts from your sources and gives feedback on what you submit—useful when exams require written answers, not only multiple choice.",
+      },
+    ],
+    ctaLabel: "Try SolomindLM free",
+    conversionPromise: "Try SolomindLM free with your own PDFs, papers, and lecture materials.",
+    signupIntentKey: "sourceUpload",
+    breadcrumbParent: { name: "Compare", path: "/compare/solomindlm-vs-notebooklm" },
+    navLabel: "SolomindLM vs NotebookLM",
+    relatedLinks: [
+      {
+        path: "/students/ai-written-questions",
+        label: "Written questions with feedback",
+        description:
+          "Practice short-answer and essay responses from your sources—SolomindLM grades your answers, not just multiple choice.",
+      },
+      {
+        path: "/guides/how-to-study-from-pdfs-with-ai",
+        label: "How to study from PDFs with AI",
+        description:
+          "Step-by-step workflow for turning readings into flashcards, quizzes, and study guides.",
+      },
+      {
+        path: "/students/ai-flashcards",
+        label: "AI flashcards",
+        description: "Generate flashcard decks grounded in your uploaded sources.",
+      },
+      {
+        path: "/research/ai-literature-review",
+        label: "AI literature review",
+        description: "Synthesize themes and gaps across papers in a research notebook.",
+      },
+    ],
+    articleType: "TechArticle",
+    changefreq: "monthly",
+    priority: 0.85,
+  },
+  {
+    path: "/guides/how-to-study-from-pdfs-with-ai",
+    pageType: "guide",
+    title: "How to Study From PDFs With AI",
+    description:
+      "Learn how to turn PDFs, lecture notes, and class readings into flashcards, quizzes, mind maps, audio overviews, and study guides with SolomindLM.",
+    keywords:
+      "how to study from PDFs with AI, AI flashcards from PDF, turn lecture slides into quizzes, chat with PDF study guide",
+    h1: "How to Study From PDFs With AI",
+    intro:
+      "The best AI study workflow starts with your own material: textbook chapters, lecture slides, reading packets, and notes. SolomindLM is built for this workflow by letting you upload sources into a notebook, chat with them, and turn them into flashcards, quizzes, written questions with feedback, mind maps, reports, and audio overviews—all grounded in the documents you provide.",
+    sections: [
+      {
+        h2: "Step 1 — Add your source material",
+        paragraphs: [
+          "Create a notebook and upload textbook PDFs, lecture slides, notes, or other study documents. You can also add discovered web sources alongside class material when you need extra context.",
+        ],
+        bullets: [
+          "Upload PDFs, Word files, PowerPoint slides, images, or audio",
+          "Paste text or import transcripts from supported video platforms",
+          "Discover web articles to supplement your readings",
+        ],
+      },
+      {
+        h2: "Step 2 — Ask grounded questions first",
+        paragraphs: [
+          "Before generating study aids, ask the notebook to explain difficult sections, define terms, compare ideas, or summarize a chapter from your uploaded sources. This checks whether your source set is complete and helps you understand the material before you memorize outputs.",
+        ],
+      },
+      {
+        h2: "Step 3 — Generate the right output for the task",
+        paragraphs: [
+          "Select the sources you want, then open the Studio tool that matches how you study. Each output is drafted from your materials—you review and edit before relying on it.",
+        ],
+        bullets: [
+          "Flashcards for definitions and recall-heavy subjects",
+          "Quizzes for multiple-choice self-testing before exams",
+          "Written questions for short-answer and essay practice with feedback on your responses",
+          "Mind maps for dense conceptual topics",
+          "Reports or study guides for chapter review",
+          "Audio overviews for recap-style revision",
+        ],
+      },
+      {
+        h2: "Step 4 — Edit before memorizing",
+        paragraphs: [
+          "Generated study content should be reviewed against the original material before you use it for exams or assignments. Treat AI outputs as drafts built from your sources, not as a substitute for verifying the source text.",
+        ],
+      },
+      {
+        h2: "Best workflow by use case",
+        paragraphs: [
+          "Match the output type to how the class is assessed. The same notebook can support different flows each week.",
+        ],
+        bullets: [
+          "Memorization-heavy class: PDF → flashcards → quiz",
+          "Essay or short-answer exams: PDF → written questions → review feedback against sources",
+          "Theory-heavy class: PDF + slides → mind map → study guide",
+          "Fast revision: readings → audio overview → short quiz",
+        ],
+      },
+      {
+        h2: "Why this works better than manual copying",
+        paragraphs: [
+          "SolomindLM starts from your actual study sources rather than asking you to build everything card by card. That makes it closer to a source-grounded study workflow than a blank flashcard app—you upload once, then branch into the formats you need for each exam.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Can AI make flashcards from PDFs?",
+        answer:
+          "Yes. Upload or paste your PDF into a SolomindLM notebook, select the sources, and generate a flashcard deck. Review and edit each card against the original text before studying.",
+      },
+      {
+        question: "Can I turn lecture slides into quizzes?",
+        answer:
+          "Yes. Add slide decks to your notebook, select them in Studio, and generate a multiple-choice quiz. Use chat first to clarify confusing slides, then generate the quiz from the same sources.",
+      },
+      {
+        question: "Should I trust AI-generated study materials?",
+        answer:
+          "Treat them as drafts. SolomindLM grounds outputs in your uploads, but you should verify wording, definitions, and edge cases against the original PDFs before exams or graded work.",
+      },
+      {
+        question: "Do I need to upload sources first?",
+        answer:
+          "Yes. Studio tools work on sources in your notebook. Add PDFs, slides, or other materials first, then generate flashcards, quizzes, mind maps, and other outputs from the selection you choose.",
+      },
+      {
+        question: "Can I practice essay answers, not just multiple choice?",
+        answer:
+          "Yes. Use Written Questions in Studio for short-answer and essay prompts grounded in your PDFs, with feedback on responses you submit. Use Quizzes when you specifically want multiple-choice practice.",
+      },
+    ],
+    ctaLabel: "Create free account",
+    conversionPromise:
+      "Upload your first PDFs and generate study materials in minutes—no credit card required.",
+    signupIntentKey: "flashcards",
+    breadcrumbParent: { name: "Guides", path: "/guides/how-to-study-from-pdfs-with-ai" },
+    navLabel: "Study from PDFs with AI",
+    relatedLinks: [
+      {
+        path: "/students/ai-written-questions",
+        label: "Written questions with feedback",
+        description:
+          "Generate short-answer and essay prompts from your PDFs and get feedback on what you write.",
+      },
+      {
+        path: "/students/ai-flashcards",
+        label: "AI flashcards",
+        description: "Generate and edit flashcard decks from notebook sources.",
+      },
+      {
+        path: "/students/ai-quizzes",
+        label: "AI quizzes",
+        description: "Build multiple-choice practice from lectures and readings.",
+      },
+      {
+        path: "/compare/solomindlm-vs-notebooklm",
+        label: "SolomindLM vs NotebookLM",
+        description: "See how written questions with feedback compares to NotebookLM study tools.",
+      },
+    ],
+    articleType: "TechArticle",
+    changefreq: "monthly",
+    priority: 0.8,
+  },
+  {
+    path: "/guides/how-to-do-an-ai-literature-review",
+    pageType: "guide",
+    title: "How to Do an AI Literature Review With Your Papers",
+    description:
+      "Learn how to discover papers, import sources, chat with your reading list, and synthesize themes and gaps with SolomindLM's AI literature review workflow.",
+    keywords:
+      "how to do literature review with AI, AI literature review from papers, chat with papers synthesize themes, import DOI BibTeX Zotero literature review",
+    h1: "How to Do an AI Literature Review With Your Papers",
+    intro:
+      "A useful AI literature review workflow starts with a real paper set, not a generic prompt. SolomindLM supports research notebooks with academic paper discovery, paper import, chat with papers, citation styles, literature review, and deep research workflows—so synthesis stays grounded in the sources you add.",
+    sections: [
+      {
+        h2: "Step 1 — Build the paper set",
+        paragraphs: [
+          "Start by discovering or importing papers into one research notebook. Scope the topic early so chat and literature review run on a coherent reading list rather than a random pile of PDFs.",
+        ],
+        bullets: [
+          "Discover papers through academic search in SolomindLM",
+          "Import via DOI, BibTeX, Zotero, or Mendeley",
+          "Upload PDFs directly when you already have files",
+        ],
+      },
+      {
+        h2: "Step 2 — Read through chat before synthesis",
+        paragraphs: [
+          "Use notebook chat to orient yourself before running a full literature review. Ask about themes, disagreements, methods, recurring limitations, and missing angles across the papers you selected.",
+        ],
+        bullets: [
+          "What are the main themes across these papers?",
+          "Where do authors disagree on methods or conclusions?",
+          "What limitations appear repeatedly?",
+          "Which subtopics are under-covered?",
+        ],
+      },
+      {
+        h2: "Step 3 — Run literature review mode",
+        paragraphs: [
+          "When the source set is scoped and cleaned, use AI literature review to synthesize themes and gaps across papers already in the notebook. This step works best after you have removed irrelevant uploads and confirmed the reading list matches your research question.",
+        ],
+      },
+      {
+        h2: "Step 4 — Format citations and outputs",
+        paragraphs: [
+          "Format references in the citation style you need, then turn the notebook into a report or deep research output when you need a longer deliverable. Verify every citation against the original papers and your style guide before submission.",
+        ],
+      },
+      {
+        h2: "What AI literature review is good for",
+        paragraphs: [
+          "AI-assisted literature review helps you move faster on structured note-taking and orientation—not on replacing scholarly judgment.",
+        ],
+        bullets: [
+          "Thematic synthesis across many papers",
+          "Faster orientation in a new field",
+          "Drafting structured review notes",
+          "Finding gaps or under-covered subtopics",
+        ],
+      },
+      {
+        h2: "What it is not",
+        paragraphs: [
+          "SolomindLM is not a substitute for a preregistered or fully systematic review protocol. It does not replace manual judgment on paper quality, inclusion criteria, or claims evaluation. Use it to accelerate reading and drafting while you retain responsibility for methodology and conclusions.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Can AI summarize multiple papers?",
+        answer:
+          "Yes. Add papers to a notebook, then use chat or literature review mode to summarize themes, methods, and gaps across the set. Always verify summaries against the original PDFs.",
+      },
+      {
+        question: "Is SolomindLM a systematic review tool?",
+        answer:
+          "No. It supports AI-assisted literature review and synthesis, but not preregistered systematic review protocols, screening workflows, or meta-analysis. Use it to orient and draft—not as a replacement for formal systematic methods.",
+      },
+      {
+        question: "Can I import papers from Zotero or DOI?",
+        answer:
+          "Yes. SolomindLM supports imports from DOI, BibTeX, Zotero, and Mendeley into research notebooks alongside direct PDF uploads.",
+      },
+      {
+        question: "Can I chat with my reading list?",
+        answer:
+          "Yes. Notebook chat answers questions grounded in the papers you added—useful for comparing methods, finding disagreements, and checking whether your source set is complete before synthesis.",
+      },
+    ],
+    ctaLabel: "Start a research notebook",
+    conversionPromise:
+      "Import your reading list and run your first literature review synthesis in minutes.",
+    signupIntentKey: "literatureReview",
+    breadcrumbParent: { name: "Guides", path: "/guides/how-to-do-an-ai-literature-review" },
+    navLabel: "AI literature review guide",
+    relatedLinks: [
+      {
+        path: "/research/ai-literature-review",
+        label: "AI literature review",
+        description: "Product overview for synthesizing themes across papers.",
+      },
+      {
+        path: "/research/import-papers",
+        label: "Import papers",
+        description: "Bring in DOI, BibTeX, Zotero, and Mendeley libraries.",
+      },
+      {
+        path: "/research",
+        label: "Research tools",
+        description: "Full research workflow hub.",
+      },
+    ],
+    articleType: "TechArticle",
+    changefreq: "monthly",
+    priority: 0.8,
+  },
+];
+
+export type SeoContentBreadcrumbItem = {
+  name: string;
+  path: string;
+};
+
+export function getSeoContentPageByPath(path: string): SeoContentPageConfig | undefined {
+  const normalized = path === "" ? "/" : path.startsWith("/") ? path : `/${path}`;
+  return SEO_CONTENT_PAGES.find((page) => page.path === normalized);
+}
+
+export function getSeoContentPaths(): string[] {
+  return SEO_CONTENT_PAGES.map((page) => page.path);
+}
+
+export function getComparisonPages(): SeoContentPageConfig[] {
+  return SEO_CONTENT_PAGES.filter((page) => page.pageType === "compare");
+}
+
+export function isSeoContentPath(path: string): boolean {
+  return getSeoContentPageByPath(path) !== undefined;
+}
+
+export function getSeoContentBreadcrumbItems(
+  page: SeoContentPageConfig
+): SeoContentBreadcrumbItem[] {
+  const compareHubPath = "/compare/solomindlm-vs-notebooklm";
+  const guideHubPath = "/guides/how-to-study-from-pdfs-with-ai";
+
+  if (page.pageType === "compare") {
+    return [
+      { name: "Home", path: "/" },
+      { name: "Compare", path: compareHubPath },
+      { name: page.navLabel, path: page.path },
+    ];
+  }
+
+  return [
+    { name: "Home", path: "/" },
+    { name: "Guides", path: guideHubPath },
+    { name: page.navLabel, path: page.path },
+  ];
+}

--- a/apps/web/src/features/studio/components/SaveAsPromptModal.test.tsx
+++ b/apps/web/src/features/studio/components/SaveAsPromptModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SaveAsPromptModal } from "./SaveAsPromptModal";
@@ -298,8 +298,7 @@ describe("SaveAsPromptModal", () => {
     expect(titleInput).toHaveValue(max100); // Still 100 characters
   });
 
-  it("respects max length for description", async () => {
-    const user = userEvent.setup();
+  it("respects max length for description", () => {
     render(
       <SaveAsPromptModal
         isOpen={true}
@@ -312,7 +311,7 @@ describe("SaveAsPromptModal", () => {
     const descInput = screen.getByPlaceholderText(/Briefly describe/);
     const max300 = "y".repeat(300);
 
-    await user.type(descInput, max300);
+    fireEvent.change(descInput, { target: { value: max300 } });
 
     expect(descInput).toHaveValue(max300);
     expect(screen.getByText("300/300")).toBeInTheDocument();

--- a/apps/web/src/shared/seo/clusterHubPrerenderHtml.ts
+++ b/apps/web/src/shared/seo/clusterHubPrerenderHtml.ts
@@ -30,6 +30,23 @@ ${childLinks}
     })
     .join("\n");
 
+  const guideLinks = page.guideLinks
+    .map(
+      (link) =>
+        `          <li><a href="${escapeHtml(link.path)}">${escapeHtml(link.label)}</a>: ${escapeHtml(link.description)}</li>`
+    )
+    .join("\n");
+
+  const guideSection =
+    page.guideLinks.length > 0
+      ? `      <section aria-labelledby="seo-prerender-guides">
+        <h2 id="seo-prerender-guides">Guides and comparisons</h2>
+        <ul>
+${guideLinks}
+        </ul>
+      </section>`
+      : "";
+
   const faqItems = page.faqs
     .map(
       (faq) =>
@@ -53,6 +70,7 @@ ${summaryItems}
         <h2 id="seo-prerender-tools">Tools</h2>
 ${sectionBlocks}
       </section>
+${guideSection}
       <section aria-labelledby="seo-prerender-faq">
         <h2 id="seo-prerender-faq">Frequently asked questions</h2>
 ${faqItems}

--- a/apps/web/src/shared/seo/intentLandingPrerenderHtml.ts
+++ b/apps/web/src/shared/seo/intentLandingPrerenderHtml.ts
@@ -42,7 +42,12 @@ ${breadcrumbNav}
       </nav>
       <header>
         <h1>${escapeHtml(page.h1)}</h1>
-        <p>${escapeHtml(page.subheadline)}</p>
+        <p>${escapeHtml(page.subheadline)}</p>${
+          page.heroCrossLink
+            ? `
+        <p><strong>${escapeHtml(page.heroCrossLink.label)}</strong> ${escapeHtml(page.heroCrossLink.description)} <a href="${escapeHtml(page.heroCrossLink.path)}">Written questions with feedback</a></p>`
+            : ""
+        }
       </header>
       <section aria-labelledby="seo-prerender-highlights">
         <h2 id="seo-prerender-highlights">Why SolomindLM</h2>

--- a/apps/web/src/shared/seo/publicSeoPages.ts
+++ b/apps/web/src/shared/seo/publicSeoPages.ts
@@ -4,6 +4,11 @@ import {
   getIntentBreadcrumbItems,
   INTENT_LANDING_PAGES,
 } from "@/features/landing/intentLandingPages";
+import {
+  getSeoContentBreadcrumbItems,
+  SEO_CONTENT_LAST_UPDATED,
+  SEO_CONTENT_PAGES,
+} from "@/features/landing/seoContentPages";
 import { LEGAL_LAST_UPDATED_ISO } from "@/features/legal/legalMeta";
 import {
   SEO_DEFAULT_DESCRIPTION,
@@ -12,6 +17,7 @@ import {
   SEO_DEFAULT_TITLE,
 } from "./seoConstants";
 import {
+  generateArticleStructuredData,
   generateBreadcrumbStructuredData,
   generateFAQStructuredData,
   generateOrganizationStructuredData,
@@ -53,6 +59,29 @@ const CLUSTER_HUB_SEO_PAGES: PublicSeoPage[] = CLUSTER_HUB_PAGES.map((page) => (
   changefreq: page.changefreq ?? "weekly",
   priority: page.priority ?? 0.9,
   structuredData: generateFAQStructuredData(page.faqs),
+}));
+
+const SEO_CONTENT_SEO_PAGES: PublicSeoPage[] = SEO_CONTENT_PAGES.map((page) => ({
+  path: page.path,
+  title: page.title,
+  description: page.description,
+  keywords: page.keywords,
+  ogType: "article",
+  changefreq: page.changefreq ?? "monthly",
+  priority: page.priority ?? 0.8,
+  lastmod: SEO_CONTENT_LAST_UPDATED,
+  structuredData: [
+    generateBreadcrumbStructuredData(getSeoContentBreadcrumbItems(page)),
+    generateArticleStructuredData({
+      headline: page.h1,
+      description: page.description,
+      path: page.path,
+      datePublished: SEO_CONTENT_LAST_UPDATED,
+      dateModified: SEO_CONTENT_LAST_UPDATED,
+      articleType: page.articleType,
+    }),
+    generateFAQStructuredData(page.faqs),
+  ],
 }));
 
 const INTENT_SEO_PAGES: PublicSeoPage[] = INTENT_LANDING_PAGES.map((page) => ({
@@ -111,6 +140,7 @@ export const PUBLIC_SEO_PAGES: PublicSeoPage[] = [
   },
   ...CLUSTER_HUB_SEO_PAGES,
   ...INTENT_SEO_PAGES,
+  ...SEO_CONTENT_SEO_PAGES,
 ];
 
 export function getPublicSeoPageByPath(path: string): PublicSeoPage | undefined {

--- a/apps/web/src/shared/seo/publicSeoPrerenderHtml.ts
+++ b/apps/web/src/shared/seo/publicSeoPrerenderHtml.ts
@@ -1,11 +1,13 @@
 import { getClusterHubPageByPath } from "@/features/landing/clusterHubPages";
 import { LANDING_FAQS } from "@/features/landing/faqRegistry";
 import { getIntentLandingPageByPath } from "@/features/landing/intentLandingPages";
+import { getSeoContentPageByPath } from "@/features/landing/seoContentPages";
 import { LEGAL_LAST_UPDATED } from "@/features/legal/legalMeta";
 import { buildClusterHubPrerenderBody } from "./clusterHubPrerenderHtml";
 import { buildFaqPrerenderBody } from "./faqPrerenderHtml";
 import { buildIntentLandingPrerenderBody } from "./intentLandingPrerenderHtml";
 import { SEO_DEFAULT_DESCRIPTION } from "./seoConstants";
+import { buildSeoContentPrerenderBody } from "./seoContentPrerenderHtml";
 import { escapeHtml } from "./seoHtml";
 
 /** Static HTML body for crawlers — injected at build time into prerendered index.html. */
@@ -78,6 +80,11 @@ export function buildPublicSeoPrerenderBody(path: string): string | undefined {
   const intentPage = getIntentLandingPageByPath(path);
   if (intentPage) {
     return buildIntentLandingPrerenderBody(intentPage);
+  }
+
+  const seoContentPage = getSeoContentPageByPath(path);
+  if (seoContentPage) {
+    return buildSeoContentPrerenderBody(seoContentPage);
   }
 
   return undefined;

--- a/apps/web/src/shared/seo/seoContentPrerenderHtml.ts
+++ b/apps/web/src/shared/seo/seoContentPrerenderHtml.ts
@@ -1,0 +1,105 @@
+import {
+  getSeoContentBreadcrumbItems,
+  type SeoContentPageConfig,
+} from "@/features/landing/seoContentPages";
+import { escapeHtml } from "./seoHtml";
+
+/** Static HTML body for crawlers — injected at build time into prerendered index.html. */
+export function buildSeoContentPrerenderBody(page: SeoContentPageConfig): string {
+  const breadcrumbItems = getSeoContentBreadcrumbItems(page);
+  const breadcrumbNav = breadcrumbItems
+    .map((item, index) => {
+      const isLast = index === breadcrumbItems.length - 1;
+      const label = escapeHtml(item.name);
+      return isLast
+        ? `          <li>${label}</li>`
+        : `          <li><a href="${escapeHtml(item.path)}">${label}</a></li>`;
+    })
+    .join("\n");
+
+  const quickAnswer = page.quickAnswer
+    ? `      <section aria-labelledby="seo-prerender-quick-answer">
+        <h2 id="seo-prerender-quick-answer">Quick answer</h2>
+        ${page.quickAnswer.chooseCompetitor ? `<p><strong>NotebookLM:</strong> ${escapeHtml(page.quickAnswer.chooseCompetitor)}</p>` : ""}
+        <p><strong>SolomindLM:</strong> ${escapeHtml(page.quickAnswer.chooseSolomindlm)}</p>
+      </section>`
+    : "";
+
+  const comparisonTable = page.comparisonTable
+    ? `      <section aria-labelledby="seo-prerender-comparison">
+        <h2 id="seo-prerender-comparison">Comparison</h2>
+        <table>
+          <thead>
+            <tr><th>Topic</th><th>SolomindLM</th><th>NotebookLM</th></tr>
+          </thead>
+          <tbody>
+${page.comparisonTable
+  .map(
+    (row) =>
+      `            <tr><th scope="row">${escapeHtml(row.topic)}</th><td>${escapeHtml(row.solomindlm)}</td><td>${escapeHtml(row.competitor)}</td></tr>`
+  )
+  .join("\n")}
+          </tbody>
+        </table>
+      </section>`
+    : "";
+
+  const sections = page.sections
+    .map((section) => {
+      const paragraphs = section.paragraphs
+        .map((paragraph) => `        <p>${escapeHtml(paragraph)}</p>`)
+        .join("\n");
+      const bullets =
+        section.bullets && section.bullets.length > 0
+          ? `        <ul>\n${section.bullets.map((bullet) => `          <li>${escapeHtml(bullet)}</li>`).join("\n")}\n        </ul>`
+          : "";
+      return `      <section>\n        <h2>${escapeHtml(section.h2)}</h2>\n${paragraphs}\n${bullets}\n      </section>`;
+    })
+    .join("\n");
+
+  const faqItems = page.faqs
+    .map(
+      (faq) =>
+        `        <div>\n          <h3>${escapeHtml(faq.question)}</h3>\n          <p>${escapeHtml(faq.answer)}</p>\n        </div>`
+    )
+    .join("\n");
+
+  const relatedLinks = page.relatedLinks
+    .map(
+      (link) =>
+        `          <li><a href="${escapeHtml(link.path)}">${escapeHtml(link.label)}</a></li>`
+    )
+    .join("\n");
+
+  return `    <article data-seo-prerender="true" id="seo-prerender-content">
+      <nav aria-label="Breadcrumb">
+        <ol>
+${breadcrumbNav}
+        </ol>
+      </nav>
+      <header>
+        <h1>${escapeHtml(page.h1)}</h1>
+        <p>${escapeHtml(page.intro)}</p>
+      </header>
+${quickAnswer}
+${comparisonTable}
+${sections}
+      <section aria-labelledby="seo-prerender-faq">
+        <h2 id="seo-prerender-faq">Frequently asked questions</h2>
+${faqItems}
+      </section>
+      <section aria-labelledby="seo-prerender-related">
+        <h2 id="seo-prerender-related">Related pages</h2>
+        <ul>
+${relatedLinks}
+        </ul>
+      </section>
+      <section>
+        <h2>${escapeHtml(page.conversionPromise)}</h2>
+        <p>${escapeHtml(page.ctaLabel)}</p>
+      </section>
+      <footer>
+        <p><a href="/">SolomindLM home</a></p>
+      </footer>
+    </article>`;
+}

--- a/apps/web/src/shared/seo/seoHtml.test.ts
+++ b/apps/web/src/shared/seo/seoHtml.test.ts
@@ -4,12 +4,14 @@ import {
   getIntentLandingPageByPath,
   getIntentLandingPaths,
 } from "@/features/landing/intentLandingPages";
+import { getSeoContentPageByPath, getSeoContentPaths } from "@/features/landing/seoContentPages";
 import { buildClusterHubPrerenderBody } from "./clusterHubPrerenderHtml";
 import { buildFaqPrerenderBody } from "./faqPrerenderHtml";
 import { buildIntentLandingPrerenderBody } from "./intentLandingPrerenderHtml";
 import { getPublicSeoPageByPath } from "./publicSeoPages";
 import { buildHomePrerenderBody, buildLegalPrerenderBody } from "./publicSeoPrerenderHtml";
 import { SEO_BASE_URL } from "./seoConstants";
+import { buildSeoContentPrerenderBody } from "./seoContentPrerenderHtml";
 import { applySeoToHtml, canonicalUrl, injectPrerenderBody, seoPageToHeadInput } from "./seoHtml";
 
 const MINIMAL_HTML = `<!doctype html>
@@ -72,6 +74,19 @@ describe("intent landing SEO registry", () => {
     const structuredData = page!.structuredData as Record<string, unknown>[];
     expect(structuredData.some((item) => item["@type"] === "BreadcrumbList")).toBe(true);
     expect(structuredData.some((item) => item["@type"] === "FAQPage")).toBe(true);
+  });
+
+  it("registers all SEO content pages in the SEO registry with article structured data", () => {
+    for (const path of getSeoContentPaths()) {
+      const page = getPublicSeoPageByPath(path);
+      expect(page).toBeDefined();
+      expect(page!.ogType).toBe("article");
+
+      const structuredData = page!.structuredData as Record<string, unknown>[];
+      expect(structuredData.some((item) => item["@type"] === "BreadcrumbList")).toBe(true);
+      expect(structuredData.some((item) => item["@type"] === "TechArticle")).toBe(true);
+      expect(structuredData.some((item) => item["@type"] === "FAQPage")).toBe(true);
+    }
   });
 
   it("registers all cluster hub pages in the SEO registry", () => {
@@ -141,6 +156,20 @@ describe("injectPrerenderBody", () => {
     expect(html).toContain('data-seo-prerender="true"');
   });
 
+  it("injects SEO content page with comparison table for crawlers", () => {
+    const seoPage = getSeoContentPageByPath("/compare/solomindlm-vs-notebooklm");
+    expect(seoPage).toBeDefined();
+
+    const bodyHtml = buildSeoContentPrerenderBody(seoPage!);
+    const html = injectPrerenderBody(MINIMAL_HTML, bodyHtml);
+
+    expect(html).toContain(`<h1>${seoPage!.h1}</h1>`);
+    expect(html).toContain("Quick answer");
+    expect(html).toContain("<table>");
+    expect(html).toContain(seoPage!.faqs[0]!.answer);
+    expect(html).toContain('href="/guides/how-to-study-from-pdfs-with-ai"');
+  });
+
   it("injects cluster hub page with child tool links for crawlers", () => {
     const hubPage = getClusterHubPageByPath("/students");
     expect(hubPage).toBeDefined();
@@ -150,6 +179,8 @@ describe("injectPrerenderBody", () => {
 
     expect(html).toContain(`<h1>${hubPage!.h1}</h1>`);
     expect(html).toContain('href="/students/ai-flashcards"');
+    expect(html).toContain('href="/guides/how-to-study-from-pdfs-with-ai"');
+    expect(html).toContain('href="/compare/solomindlm-vs-notebooklm"');
     expect(html).toContain(hubPage!.faqs[0]!.answer);
   });
 });

--- a/apps/web/src/shared/seo/structuredData.test.ts
+++ b/apps/web/src/shared/seo/structuredData.test.ts
@@ -4,7 +4,15 @@ import {
   getIntentBreadcrumbItems,
   getIntentLandingPageByPath,
 } from "@/features/landing/intentLandingPages";
-import { generateBreadcrumbStructuredData, generateFAQStructuredData } from "./structuredData";
+import {
+  getSeoContentBreadcrumbItems,
+  getSeoContentPageByPath,
+} from "@/features/landing/seoContentPages";
+import {
+  generateArticleStructuredData,
+  generateBreadcrumbStructuredData,
+  generateFAQStructuredData,
+} from "./structuredData";
 
 describe("generateFAQStructuredData", () => {
   it("returns a single FAQPage with all questions in mainEntity", () => {
@@ -51,5 +59,38 @@ describe("generateBreadcrumbStructuredData", () => {
         item: "https://www.solomindlm.com/students/ai-flashcards",
       },
     ]);
+  });
+});
+
+describe("generateArticleStructuredData", () => {
+  it("returns TechArticle with canonical URL for SEO content pages", () => {
+    const page = getSeoContentPageByPath("/guides/how-to-study-from-pdfs-with-ai");
+    expect(page).toBeDefined();
+
+    const data = generateArticleStructuredData({
+      headline: page!.h1,
+      description: page!.description,
+      path: page!.path,
+      datePublished: "2026-06-07",
+      dateModified: "2026-06-07",
+      articleType: page!.articleType,
+    });
+
+    expect(data["@type"]).toBe("TechArticle");
+    expect(data.url).toBe("https://www.solomindlm.com/guides/how-to-study-from-pdfs-with-ai");
+    expect(data.headline).toBe(page!.h1);
+  });
+
+  it("returns BreadcrumbList for SEO content guide pages", () => {
+    const page = getSeoContentPageByPath("/guides/how-to-do-an-ai-literature-review");
+    expect(page).toBeDefined();
+
+    const data = generateBreadcrumbStructuredData(getSeoContentBreadcrumbItems(page!));
+
+    expect(data.itemListElement).toHaveLength(3);
+    expect(data.itemListElement[1]).toMatchObject({
+      name: "Guides",
+      item: "https://www.solomindlm.com/guides/how-to-study-from-pdfs-with-ai",
+    });
   });
 });

--- a/apps/web/src/shared/seo/structuredData.ts
+++ b/apps/web/src/shared/seo/structuredData.ts
@@ -56,6 +56,46 @@ export type BreadcrumbItem = {
   path: string;
 };
 
+export type ArticleStructuredDataParams = {
+  headline: string;
+  description: string;
+  path: string;
+  datePublished: string;
+  dateModified: string;
+  articleType?: "Article" | "TechArticle";
+};
+
+export const generateArticleStructuredData = ({
+  headline,
+  description,
+  path,
+  datePublished,
+  dateModified,
+  articleType = "Article",
+}: ArticleStructuredDataParams) => ({
+  "@context": "https://schema.org",
+  "@type": articleType,
+  headline,
+  description,
+  url: `${SEO_BASE_URL}${path}`,
+  datePublished,
+  dateModified,
+  author: {
+    "@type": "Organization",
+    name: "SolomindLM",
+    url: SEO_BASE_URL,
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "SolomindLM",
+    logo: {
+      "@type": "ImageObject",
+      url: SEO_DEFAULT_OG_IMAGE,
+    },
+  },
+  mainEntityOfPage: `${SEO_BASE_URL}${path}`,
+});
+
 export const generateBreadcrumbStructuredData = (items: BreadcrumbItem[]) => ({
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",


### PR DESCRIPTION
## Summary
- Add three programmatic SEO pages: SolomindLM vs NotebookLM compare, PDF study guide, and AI literature review guide (routes, prerender HTML, TechArticle + FAQ JSON-LD).
- Wire hub guide links, footer Comparisons column, sitemap, and expanded `llms.txt` / new `llms-full.txt` with essay-practice and NotebookLM written-questions search intents.
- Surface written questions and citation-style differentiators on the compare page; add quiz intent hero cross-link to written questions.
- Fix flaky `SaveAsPromptModal` description max-length test (use `fireEvent.change` instead of typing 300 chars).

## Test plan
- [x] `bun run typecheck:web` + `typecheck:convex`
- [x] `bun run lint`
- [x] `bun run test:web`
- [x] Web production build
- [ ] CI green on PR