### PR TITLE
feat(studio): literature review toolbar, labels, and table save

### DIFF
--- a/apps/web/src/features/notebooks/components/views/NotebookView.tsx
+++ b/apps/web/src/features/notebooks/components/views/NotebookView.tsx
@@ -139,6 +139,13 @@ export function NotebookView() {
     setMobileActiveTab("studio");
   }, []);
 
+  const handleOpenSavedSpreadsheet = useCallback((spreadsheetId: Id<"spreadsheets">) => {
+    window.dispatchEvent(new CustomEvent("setActiveNote", { detail: { noteId: spreadsheetId } }));
+    setActiveLiteratureView(null);
+    setIsStudioOpen(true);
+    setMobileActiveTab("studio");
+  }, []);
+
   const toggleSources = () => setIsSourcesOpen(!isSourcesOpen);
 
   const toggleStudio = useCallback(() => setIsStudioOpen((isOpen) => !isOpen), []);
@@ -177,6 +184,7 @@ export function NotebookView() {
           notebookId={urlNotebookId as Id<"notebooks">}
           onClose={handleCloseLiteratureView}
           onOpenSavedReport={handleOpenSavedReport}
+          onOpenSavedSpreadsheet={handleOpenSavedSpreadsheet}
         />
       );
     }
@@ -197,6 +205,7 @@ export function NotebookView() {
 
     handleCloseLiteratureView,
     handleOpenSavedReport,
+    handleOpenSavedSpreadsheet,
 
     isResizingRight,
 
@@ -365,6 +374,7 @@ export function NotebookView() {
           notebookId={urlNotebookId as Id<"notebooks">}
           onClose={handleCloseLiteratureView}
           onOpenSavedReport={handleOpenSavedReport}
+          onOpenSavedSpreadsheet={handleOpenSavedSpreadsheet}
         />
       );
     }
@@ -384,6 +394,7 @@ export function NotebookView() {
     activeLiteratureView,
     handleCloseLiteratureView,
     handleOpenSavedReport,
+    handleOpenSavedSpreadsheet,
     sources,
     urlNotebookId,
   ]);

--- a/apps/web/src/features/studio/components/LiteratureStudioView.tsx
+++ b/apps/web/src/features/studio/components/LiteratureStudioView.tsx
@@ -1,11 +1,14 @@
 import type { Id } from "@convex/_generated/dataModel";
 import { Loader2 } from "lucide-react";
-import React from "react";
+import React, { useCallback, useState } from "react";
+import { useToast } from "@/shared/contexts/useToast";
 import {
   useLiteratureReportDetail,
   useLiteratureTable,
   useSaveLiteratureReportAsStudioReport,
+  useSaveLiteratureTableAsStudioSpreadsheet,
 } from "../services/literatureTablesApi";
+import type { LiteratureTable } from "./views/LiteratureTableView";
 import type { ActiveLiteratureView } from "../types/literatureStudio";
 import { literatureReportToolbarLabel } from "../utils/literatureReportLabels";
 import type { CitationStyle } from "./CitationStylePicker";
@@ -19,6 +22,7 @@ interface LiteratureStudioViewProps {
   notebookId: Id<"notebooks">;
   onClose: () => void;
   onOpenSavedReport?: (reportId: Id<"reports">) => void;
+  onOpenSavedSpreadsheet?: (spreadsheetId: Id<"spreadsheets">) => void;
 }
 
 export const LiteratureStudioView: React.FC<LiteratureStudioViewProps> = ({
@@ -27,6 +31,7 @@ export const LiteratureStudioView: React.FC<LiteratureStudioViewProps> = ({
   notebookId,
   onClose,
   onOpenSavedReport,
+  onOpenSavedSpreadsheet,
 }) => {
   if (view.kind === "table") {
     return (
@@ -35,6 +40,7 @@ export const LiteratureStudioView: React.FC<LiteratureStudioViewProps> = ({
         notebookId={notebookId}
         width={width}
         onClose={onClose}
+        onOpenSavedSpreadsheet={onOpenSavedSpreadsheet}
       />
     );
   }
@@ -54,13 +60,44 @@ function LiteratureTableStudioShell({
   notebookId,
   width,
   onClose,
+  onOpenSavedSpreadsheet,
 }: {
   tableId: Id<"literatureTables">;
   notebookId: Id<"notebooks">;
   width: number;
   onClose: () => void;
+  onOpenSavedSpreadsheet?: (spreadsheetId: Id<"spreadsheets">) => void;
 }) {
   const table = useLiteratureTable(tableId);
+  const saveAsStudioSpreadsheet = useSaveLiteratureTableAsStudioSpreadsheet();
+  const { success: toastSuccess, error: toastError } = useToast();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = useCallback(
+    async (nextTable: LiteratureTable) => {
+      setIsSaving(true);
+      try {
+        const spreadsheetId = await saveAsStudioSpreadsheet({
+          tableId,
+          title: nextTable.title,
+          columns: nextTable.columns,
+          papers: nextTable.papers.map((paper) => ({
+            citationId: paper.citationId as Id<"citations">,
+            rowData: paper.rowData,
+            includeReason: paper.includeReason,
+            isIncluded: paper.isIncluded,
+          })),
+        });
+        toastSuccess("Table saved to Studio");
+        onOpenSavedSpreadsheet?.(spreadsheetId);
+      } catch (err) {
+        toastError(err instanceof Error ? err.message : "Failed to save table");
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [onOpenSavedSpreadsheet, saveAsStudioSpreadsheet, tableId, toastError, toastSuccess]
+  );
 
   return (
     <PanelShell width={width} variant="table">
@@ -81,6 +118,8 @@ function LiteratureTableStudioShell({
           }}
           notebookId={notebookId}
           onBack={onClose}
+          onSave={handleSave}
+          isSaving={isSaving}
         />
       )}
     </PanelShell>

--- a/apps/web/src/features/studio/components/LiteratureStudioView.tsx
+++ b/apps/web/src/features/studio/components/LiteratureStudioView.tsx
@@ -8,12 +8,12 @@ import {
   useSaveLiteratureReportAsStudioReport,
   useSaveLiteratureTableAsStudioSpreadsheet,
 } from "../services/literatureTablesApi";
-import type { LiteratureTable } from "./views/LiteratureTableView";
 import type { ActiveLiteratureView } from "../types/literatureStudio";
 import { literatureReportToolbarLabel } from "../utils/literatureReportLabels";
 import type { CitationStyle } from "./CitationStylePicker";
 import { ResizeHandle } from "./ResizeHandle";
 import { LiteratureReportView } from "./views/LiteratureReportView";
+import type { LiteratureTable } from "./views/LiteratureTableView";
 import { LiteratureTableView } from "./views/LiteratureTableView";
 
 interface LiteratureStudioViewProps {
@@ -139,11 +139,17 @@ function LiteratureReportStudioShell({
 }) {
   const detail = useLiteratureReportDetail(reportId);
   const saveAsStudioReport = useSaveLiteratureReportAsStudioReport();
+  const { success: toastSuccess, error: toastError } = useToast();
 
-  const handleSaveAndEdit = async () => {
-    const savedReportId = await saveAsStudioReport({ reportId });
-    onOpenSavedReport?.(savedReportId);
-  };
+  const handleSaveAndEdit = useCallback(async () => {
+    try {
+      const savedReportId = await saveAsStudioReport({ reportId });
+      toastSuccess("Report saved to Studio");
+      onOpenSavedReport?.(savedReportId);
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : "Failed to save report");
+    }
+  }, [onOpenSavedReport, reportId, saveAsStudioReport, toastError, toastSuccess]);
 
   return (
     <PanelShell width={width}>

--- a/apps/web/src/features/studio/components/NoteIcon.tsx
+++ b/apps/web/src/features/studio/components/NoteIcon.tsx
@@ -1,5 +1,6 @@
 import {
   AudioLines,
+  BookOpen,
   FileText,
   GitFork,
   HelpCircle,
@@ -10,7 +11,8 @@ import {
   Table2,
 } from "lucide-react";
 import React from "react";
-import { Note } from "@/shared/types/index";
+import { isReportNote, Note } from "@/shared/types/index";
+import { isLiteratureReviewReportType } from "@/shared/types/reportTypes";
 
 interface NoteIconProps {
   note: Note;
@@ -26,6 +28,14 @@ export const NoteIcon: React.FC<NoteIconProps> = ({ note }) => {
     return (
       <div className="shrink-0 w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
         <Loader2 className="w-4 h-4 text-primary animate-spin" />
+      </div>
+    );
+  }
+
+  if (isReportNote(note) && isLiteratureReviewReportType(note.metadata.reportType)) {
+    return (
+      <div className="shrink-0 w-8 h-8 rounded-lg bg-orange-500/10 text-orange-600 flex items-center justify-center">
+        <BookOpen className="w-4 h-4 shrink-0" />
       </div>
     );
   }

--- a/apps/web/src/features/studio/components/StudioPanel.tsx
+++ b/apps/web/src/features/studio/components/StudioPanel.tsx
@@ -126,8 +126,8 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
       const noteId = customEvent.detail?.noteId;
       if (noteId) {
         const note = notes.find((n) => n.id === noteId);
-        // Prevent setting generating notes as active
-        if (note && note.status !== "generating") {
+        // Allow selecting notes not yet in the list (e.g. right after first save)
+        if (!note || note.status !== "generating") {
           setActiveNoteId(noteId);
         }
       }

--- a/apps/web/src/features/studio/components/views/LiteratureReportView.tsx
+++ b/apps/web/src/features/studio/components/views/LiteratureReportView.tsx
@@ -2,9 +2,21 @@ import {
   normalizeLiteratureReportSectionContent,
   stripLeadingSectionHeadingLine,
 } from "@convex/literatureReview/reportContext";
-import { ArrowLeft, Check, Copy, Download, FileText, Loader2, Save, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  Download,
+  FileDown,
+  FileText,
+  Loader2,
+  Printer,
+  Save,
+  X,
+} from "lucide-react";
 import React, { lazy, Suspense, useMemo, useState } from "react";
-import { sanitizeMarkdown } from "@/shared/utils";
+import { DropdownMenu } from "@/shared/ui/DropdownMenu";
+import { cn, sanitizeMarkdown } from "@/shared/utils";
 import { CitationStyle, CitationStylePicker } from "../CitationStylePicker";
 import { type PrismaFlowCounts, PrismaFlowDiagram } from "../PrismaFlowDiagram";
 
@@ -234,8 +246,32 @@ function exportToMarkdown(report: LiteratureReport, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-const REPORT_TOOLBAR_TEXT_BTN =
-  "hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-sm font-normal text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50";
+const REPORT_TOOLBAR_BTN = cn(
+  "inline-flex shrink-0 items-center gap-2 rounded-md px-2.5 py-1.5 text-sm font-normal text-foreground transition-colors",
+  "hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+);
+
+function ExportMenuItem({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
 
 export const LiteratureReportView: React.FC<LiteratureReportViewProps> = ({
   report,
@@ -258,6 +294,14 @@ export const LiteratureReportView: React.FC<LiteratureReportViewProps> = ({
 
   const handleExportPdf = () => {
     window.print();
+  };
+
+  const handleExportMarkdown = () => {
+    if (onExport) {
+      onExport();
+      return;
+    }
+    exportToMarkdown(report, `${report.title.replace(/\s+/g, "_")}.md`);
   };
 
   const handleSaveAndEdit = async () => {
@@ -302,59 +346,68 @@ export const LiteratureReportView: React.FC<LiteratureReportViewProps> = ({
           <button
             type="button"
             onClick={handleCopyReport}
-            className={`${REPORT_TOOLBAR_TEXT_BTN} @min-[720px]/report-toolbar:inline-flex`}
+            className={REPORT_TOOLBAR_BTN}
             title={didCopyReport ? "Copied report" : "Copy with citations"}
+            aria-label={didCopyReport ? "Copied report" : "Copy with citations"}
           >
             {didCopyReport ? (
               <Check className="h-4 w-4 shrink-0" strokeWidth={2} />
             ) : (
               <Copy className="h-4 w-4 shrink-0" strokeWidth={2} />
             )}
-            <span>{didCopyReport ? "Copied" : "Copy with citations"}</span>
+            <span className="hidden @min-[520px]/report-toolbar:inline">
+              {didCopyReport ? "Copied" : "Copy with citations"}
+            </span>
           </button>
-          <button
-            type="button"
-            onClick={handleExportPdf}
-            className={`${REPORT_TOOLBAR_TEXT_BTN} @min-[820px]/report-toolbar:inline-flex`}
-            title="Export PDF"
+          <DropdownMenu
+            trigger={
+              <button
+                type="button"
+                className={REPORT_TOOLBAR_BTN}
+                title="Export report"
+                aria-label="Export report"
+              >
+                <Download className="h-4 w-4 shrink-0" strokeWidth={2} />
+              </button>
+            }
           >
-            <Download className="h-4 w-4 shrink-0" strokeWidth={2} />
-            <span>Export PDF</span>
-          </button>
+            <ExportMenuItem
+              icon={<Printer className="h-4 w-4" />}
+              label="Export PDF"
+              onClick={handleExportPdf}
+            />
+            <ExportMenuItem
+              icon={<FileDown className="h-4 w-4" />}
+              label="Export Markdown (.md)"
+              onClick={handleExportMarkdown}
+            />
+          </DropdownMenu>
           <button
             type="button"
             onClick={handleSaveAndEdit}
             disabled={!onSaveAndEdit || isSaving}
-            className={`${REPORT_TOOLBAR_TEXT_BTN} @min-[940px]/report-toolbar:inline-flex`}
+            className={REPORT_TOOLBAR_BTN}
             title="Save & Edit Document"
+            aria-label={isSaving ? "Saving document" : "Save and edit document"}
           >
             {isSaving ? (
               <Loader2 className="h-4 w-4 shrink-0 animate-spin" strokeWidth={2} />
             ) : (
               <Save className="h-4 w-4 shrink-0" strokeWidth={2} />
             )}
-            <span>{isSaving ? "Saving..." : "Save & Edit Document"}</span>
-          </button>
-          <button
-            onClick={
-              onExport
-                ? onExport
-                : () => exportToMarkdown(report, `${report.title.replace(/\s+/g, "_")}.md`)
-            }
-            className="inline-flex shrink-0 items-center justify-center rounded-md p-1.5 text-foreground transition-colors hover:bg-secondary @min-[720px]/report-toolbar:hidden"
-            aria-label="Export report as Markdown"
-            title="Export report as Markdown"
-          >
-            <Download className="w-4 h-4 shrink-0" />
+            <span className="hidden @min-[700px]/report-toolbar:inline">
+              {isSaving ? "Saving..." : "Save & Edit Document"}
+            </span>
           </button>
           {onBack && (
             <button
+              type="button"
               onClick={onBack}
-              className="inline-flex shrink-0 rounded-md p-1.5 text-foreground transition-colors hover:bg-secondary"
+              className={REPORT_TOOLBAR_BTN}
               aria-label={`Close ${toolbarLabel.toLowerCase()}`}
               title="Close"
             >
-              <X className="w-4 h-4 shrink-0" />
+              <X className="h-4 w-4 shrink-0" strokeWidth={2} />
             </button>
           )}
         </div>

--- a/apps/web/src/features/studio/components/views/LiteratureTableView.tsx
+++ b/apps/web/src/features/studio/components/views/LiteratureTableView.tsx
@@ -53,7 +53,8 @@ export interface LiteratureTableViewProps {
   table: LiteratureTable;
   notebookId: Id<"notebooks">;
   onBack?: () => void;
-  onSave?: (table: LiteratureTable) => void;
+  onSave?: (table: LiteratureTable) => void | Promise<void>;
+  isSaving?: boolean;
   onExport?: (format: "csv" | "excel") => void;
   onAddPapers?: () => void;
 }
@@ -155,6 +156,7 @@ export const LiteratureTableView: React.FC<LiteratureTableViewProps> = ({
   notebookId,
   onBack,
   onSave,
+  isSaving = false,
   onExport,
   onAddPapers,
 }) => {
@@ -356,12 +358,20 @@ export const LiteratureTableView: React.FC<LiteratureTableViewProps> = ({
           </button>
           <button
             type="button"
-            onClick={() => onSave?.(table)}
-            title="Save table"
+            onClick={() => void onSave?.(table)}
+            disabled={!onSave || isSaving}
+            title="Save table to Studio"
+            aria-label={isSaving ? "Saving table" : "Save table to Studio"}
             className={TABLE_TOOLBAR_BTN}
           >
-            <Save className="h-4 w-4 shrink-0" strokeWidth={2} />
-            <span className="hidden @min-[860px]/table-toolbar:inline">Save table</span>
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin" strokeWidth={2} />
+            ) : (
+              <Save className="h-4 w-4 shrink-0" strokeWidth={2} />
+            )}
+            <span className="hidden @min-[860px]/table-toolbar:inline">
+              {isSaving ? "Saving..." : "Save table"}
+            </span>
           </button>
           <DropdownMenu
             trigger={

--- a/apps/web/src/features/studio/components/views/LiteratureTableView.tsx
+++ b/apps/web/src/features/studio/components/views/LiteratureTableView.tsx
@@ -91,11 +91,13 @@ function exportToCSV(table: LiteratureTable, filename: string) {
   const dataColumns = table.columns.filter(isDataColumn).sort((a, b) => a.order - b.order);
   const headers = ["Paper", ...dataColumns.map((c) => c.name)];
 
-  const rows = table.papers.map((paper) => {
-    const title = getPaperTitle(paper, table.columns);
-    const values = dataColumns.map((col) => paper.rowData[col.id] || "");
-    return [title, ...values];
-  });
+  const rows = table.papers
+    .filter((paper) => paper.isIncluded)
+    .map((paper) => {
+      const title = getPaperTitle(paper, table.columns);
+      const values = dataColumns.map((col) => paper.rowData[col.id] || "");
+      return [title, ...values];
+    });
 
   const escapeCSV = (value: string) => {
     if (value.includes(",") || value.includes('"') || value.includes("\n")) {

--- a/apps/web/src/features/studio/services/literatureTablesApi.ts
+++ b/apps/web/src/features/studio/services/literatureTablesApi.ts
@@ -59,3 +59,7 @@ export function useRetryLiteratureReview() {
 export function useSaveLiteratureReportAsStudioReport() {
   return useMutation(api.studio.literature_tables.index.saveLiteratureReportAsStudioReport);
 }
+
+export function useSaveLiteratureTableAsStudioSpreadsheet() {
+  return useMutation(api.studio.literature_tables.index.saveLiteratureTableAsStudioSpreadsheet);
+}

--- a/apps/web/src/features/studio/services/spreadsheetsApi.ts
+++ b/apps/web/src/features/studio/services/spreadsheetsApi.ts
@@ -27,6 +27,7 @@ export function getSpreadsheetTypeLabel(spreadsheetType: string): string {
     timeline: "Timeline",
     financial_summary: "Financial",
     custom: "Custom",
+    literature_review: "Literature Review",
   };
   return labels[spreadsheetType] || "Spreadsheet";
 }

--- a/apps/web/src/shared/types/reportTypes.ts
+++ b/apps/web/src/shared/types/reportTypes.ts
@@ -49,6 +49,11 @@ export const REPORT_TYPES: Record<string, ReportTypeConfig> = {
     displayName: "Methodology Overview",
     description: "Methodology Overview",
   },
+  literature_review: {
+    id: "literature_review",
+    displayName: "Literature Review",
+    description: "Literature Review",
+  },
 };
 
 /**
@@ -89,8 +94,15 @@ export function getReportTypeDisplayName(reportTypeId: string): string {
  * @param reportTypeId - The report type ID
  * @returns The subtitle string in format "Report · {DisplayName}"
  */
+export function isLiteratureReviewReportType(reportTypeId: string): boolean {
+  return normalizeReportTypeId(reportTypeId) === "literature_review";
+}
+
 export function getReportSubtitle(reportTypeId: string): string {
   const normalized = normalizeReportTypeId(reportTypeId);
+  if (normalized === "literature_review") {
+    return "Literature Review";
+  }
   const displayName = getReportTypeDisplayName(normalized);
   return `Report · ${displayName}`;
 }

--- a/apps/web/src/shared/ui/DropdownMenu.tsx
+++ b/apps/web/src/shared/ui/DropdownMenu.tsx
@@ -1,9 +1,31 @@
-import React, { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
+import React, { ReactElement, ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface DropdownMenuProps {
   trigger: ReactElement<any>;
   children: ReactNode;
   align?: "left" | "right";
+}
+
+type MenuPosition =
+  | { top: number; left: number; right?: undefined }
+  | { top: number; right: number; left?: undefined };
+
+function getMenuPosition(trigger: HTMLElement, align: "left" | "right"): MenuPosition {
+  const rect = trigger.getBoundingClientRect();
+  const gap = 8;
+
+  if (align === "right") {
+    return {
+      top: rect.bottom + gap,
+      right: window.innerWidth - rect.right,
+    };
+  }
+
+  return {
+    top: rect.bottom + gap,
+    left: rect.left,
+  };
 }
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({
@@ -12,14 +34,41 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   align = "right",
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const updateMenuPosition = () => {
+    if (!containerRef.current) return;
+    setMenuPosition(getMenuPosition(containerRef.current, align));
+  };
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setMenuPosition(null);
+      return;
+    }
+
+    updateMenuPosition();
+
+    const handleReposition = () => updateMenuPosition();
+    window.addEventListener("resize", handleReposition);
+    window.addEventListener("scroll", handleReposition, true);
+
+    return () => {
+      window.removeEventListener("resize", handleReposition);
+      window.removeEventListener("scroll", handleReposition, true);
+    };
+  }, [isOpen, align]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+      const target = event.target as Node;
+      if (containerRef.current?.contains(target) || menuRef.current?.contains(target)) {
+        return;
       }
+      setIsOpen(false);
     };
 
     const handleEscape = (event: KeyboardEvent) => {
@@ -45,8 +94,6 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     setIsOpen((prev) => !prev);
   };
 
-  const alignClass = align === "left" ? "left-0" : "right-0";
-
   // Clone trigger and add onClick handler
   const triggerWithProps = React.cloneElement(trigger, {
     onClick: handleTriggerClick,
@@ -54,27 +101,36 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     "aria-expanded": isOpen,
   });
 
+  const menu =
+    isOpen && menuPosition ? (
+      <div
+        ref={menuRef}
+        role="menu"
+        style={
+          menuPosition.right != null
+            ? { top: menuPosition.top, right: menuPosition.right }
+            : { top: menuPosition.top, left: menuPosition.left }
+        }
+        className="fixed z-200 min-w-[200px] bg-card border border-border rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200"
+        onClick={(e) => {
+          const menuItem = (e.target as HTMLElement).closest<HTMLElement>('[role="menuitem"]');
+          const opensSubmenu =
+            menuItem?.hasAttribute("aria-haspopup") &&
+            menuItem.getAttribute("aria-haspopup") !== "false";
+
+          if (menuItem && !opensSubmenu) {
+            setIsOpen(false);
+          }
+        }}
+      >
+        {children}
+      </div>
+    ) : null;
+
   return (
     <div ref={containerRef} className="relative">
       {triggerWithProps}
-      {isOpen && (
-        <div
-          role="menu"
-          className={`absolute top-full mt-2 ${alignClass} z-200 min-w-[200px] bg-card border border-border rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200`}
-          onClick={(e) => {
-            const menuItem = (e.target as HTMLElement).closest<HTMLElement>('[role="menuitem"]');
-            const opensSubmenu =
-              menuItem?.hasAttribute("aria-haspopup") &&
-              menuItem.getAttribute("aria-haspopup") !== "false";
-
-            if (menuItem && !opensSubmenu) {
-              setIsOpen(false);
-            }
-          }}
-        >
-          {children}
-        </div>
-      )}
+      {typeof document !== "undefined" && menu ? createPortal(menu, document.body) : null}
     </div>
   );
 };

--- a/apps/web/src/shared/ui/DropdownMenu.tsx
+++ b/apps/web/src/shared/ui/DropdownMenu.tsx
@@ -1,4 +1,11 @@
-import React, { ReactElement, ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 interface DropdownMenuProps {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -325,6 +325,7 @@ import type * as studio_jobMutations_reports from "../studio/jobMutations/report
 import type * as studio_jobMutations_spreadsheets from "../studio/jobMutations/spreadsheets.js";
 import type * as studio_jobMutations_writtenQuestions from "../studio/jobMutations/writtenQuestions.js";
 import type * as studio_literature_tables_index from "../studio/literature_tables/index.js";
+import type * as studio_literature_tables_literatureTableCsv from "../studio/literature_tables/literatureTableCsv.js";
 import type * as studio_mindmaps_index from "../studio/mindmaps/index.js";
 import type * as studio_mindmaps_job from "../studio/mindmaps/job.js";
 import type * as studio_mindmaps_mindmapJobPhases from "../studio/mindmaps/mindmapJobPhases.js";
@@ -675,6 +676,7 @@ declare const fullApi: ApiFromModules<{
   "studio/jobMutations/spreadsheets": typeof studio_jobMutations_spreadsheets;
   "studio/jobMutations/writtenQuestions": typeof studio_jobMutations_writtenQuestions;
   "studio/literature_tables/index": typeof studio_literature_tables_index;
+  "studio/literature_tables/literatureTableCsv": typeof studio_literature_tables_literatureTableCsv;
   "studio/mindmaps/index": typeof studio_mindmaps_index;
   "studio/mindmaps/job": typeof studio_mindmaps_job;
   "studio/mindmaps/mindmapJobPhases": typeof studio_mindmaps_mindmapJobPhases;

--- a/convex/studio/literature_tables/index.test.ts
+++ b/convex/studio/literature_tables/index.test.ts
@@ -56,6 +56,66 @@ async function seedLiteratureReport(
   );
 }
 
+async function seedCitation(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">
+): Promise<Id<"citations">> {
+  return t.run(async (ctx) =>
+    ctx.db.insert("citations", {
+      paperId: `paper-${userId}`,
+      title: "Sample Paper",
+      authors: ["Ada Lovelace"],
+      year: 2024,
+      url: "https://example.com/paper",
+      sourceApi: "openalex",
+      citationKey: "lovelace2024sample",
+    })
+  );
+}
+
+async function seedLiteratureTable(
+  t: ReturnType<typeof convexTest>,
+  userId: Id<"users">,
+  notebookId: Id<"notebooks">,
+  citationId: Id<"citations">
+): Promise<Id<"literatureTables">> {
+  return t.run(async (ctx) =>
+    ctx.db.insert("literatureTables", {
+      userId,
+      notebookId,
+      title: "Literature Table",
+      status: "completed",
+      columns: [
+        {
+          id: "paper_title",
+          name: "Paper",
+          type: "paper_title",
+          isVisible: true,
+          isSystem: true,
+          order: 0,
+        },
+        {
+          id: "finding",
+          name: "Finding",
+          type: "custom",
+          isVisible: true,
+          isSystem: false,
+          order: 1,
+        },
+      ],
+      papers: [
+        {
+          citationId,
+          rowData: { finding: "Important result" },
+          isIncluded: true,
+        },
+      ],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  );
+}
+
 describe("saveLiteratureReportAsStudioReport", () => {
   test("copies a literature report into the Studio saved reports list", async () => {
     const t = convexTest(schema, modules);
@@ -95,6 +155,99 @@ describe("saveLiteratureReportAsStudioReport", () => {
             reportType: "literature_review",
             sourceLiteratureReportId: literatureReportId,
             citationStyle: "apa7",
+          }),
+        }),
+      ])
+    );
+  });
+});
+
+describe("saveLiteratureTableAsStudioSpreadsheet", () => {
+  test("persists table edits and copies the table into the Studio spreadsheets list", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t);
+    const notebookId = await seedNotebook(t, userId);
+    const citationId = await seedCitation(t, userId);
+    const literatureTableId = await seedLiteratureTable(t, userId, notebookId, citationId);
+
+    const saveLiteratureTableAsStudioSpreadsheet = (
+      api.studio.literature_tables.index as {
+        saveLiteratureTableAsStudioSpreadsheet: FunctionReference<
+          "mutation",
+          "public",
+          {
+            tableId: Id<"literatureTables">;
+            title: string;
+            columns: Array<{
+              id: string;
+              name: string;
+              type: "paper_title" | "authors" | "year" | "study_type" | "custom";
+              instructions?: string;
+              isVisible: boolean;
+              isSystem: boolean;
+              order: number;
+            }>;
+            papers: Array<{
+              citationId: Id<"citations">;
+              rowData: Record<string, string>;
+              includeReason?: string;
+              isIncluded: boolean;
+            }>;
+          },
+          Id<"spreadsheets">
+        >;
+      }
+    ).saveLiteratureTableAsStudioSpreadsheet;
+
+    const spreadsheetId = await withAuth(t, userId).mutation(
+      saveLiteratureTableAsStudioSpreadsheet,
+      {
+        tableId: literatureTableId,
+        title: "Saved Literature Table",
+        columns: [
+          {
+            id: "paper_title",
+            name: "Paper",
+            type: "paper_title",
+            isVisible: true,
+            isSystem: true,
+            order: 0,
+          },
+          {
+            id: "finding",
+            name: "Finding",
+            type: "custom",
+            isVisible: true,
+            isSystem: false,
+            order: 1,
+          },
+        ],
+        papers: [
+          {
+            citationId,
+            rowData: { finding: "Updated result" },
+            isIncluded: true,
+          },
+        ],
+      }
+    );
+
+    const savedNotes = await withAuth(t, userId).query(api.notes.index.list, {
+      notebookId,
+    });
+
+    expect(spreadsheetId).toBeTruthy();
+    expect(savedNotes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _id: spreadsheetId,
+          _type: "spreadsheet",
+          title: "Saved Literature Table",
+          status: "completed",
+          data: expect.stringContaining("Updated result"),
+          metadata: expect.objectContaining({
+            spreadsheetType: "literature_review",
+            sourceLiteratureTableId: literatureTableId,
           }),
         }),
       ])

--- a/convex/studio/literature_tables/index.ts
+++ b/convex/studio/literature_tables/index.ts
@@ -11,6 +11,30 @@ import { resolveSmartModel } from "../../_lib/resolveSmartModel.js";
 import { literatureSearchOptionsValidator } from "../../_model/literatureReviewSearchOptions";
 import { getAuthUserId } from "../../auth";
 import { literatureReviewWorkflowProvenanceValidator } from "../../literatureReview/workflowProvenance";
+import { literatureTableToCsv } from "./literatureTableCsv.js";
+
+const literatureTableColumnValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  type: v.union(
+    v.literal("paper_title"),
+    v.literal("authors"),
+    v.literal("year"),
+    v.literal("study_type"),
+    v.literal("custom")
+  ),
+  instructions: v.optional(v.string()),
+  isVisible: v.boolean(),
+  isSystem: v.boolean(),
+  order: v.number(),
+});
+
+const literatureTablePaperValidator = v.object({
+  citationId: v.id("citations"),
+  rowData: v.record(v.string(), v.string()),
+  includeReason: v.optional(v.string()),
+  isIncluded: v.boolean(),
+});
 
 /** Chat workflow tables/reports — never listed in the studio sidebar. */
 async function getChatLinkedLiteratureArtifactIds(
@@ -724,6 +748,83 @@ export const saveLiteratureReportAsStudioReport = mutation({
         sourceLiteratureTableId: report.tableId,
         citationStyle: report.citationStyle,
         citationIds: report.citationIds,
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const saveLiteratureTableAsStudioSpreadsheet = mutation({
+  args: {
+    tableId: v.id("literatureTables"),
+    title: v.string(),
+    columns: v.array(literatureTableColumnValidator),
+    papers: v.array(literatureTablePaperValidator),
+  },
+  returns: v.id("spreadsheets"),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Unauthenticated");
+
+    const table = await ctx.db.get(args.tableId);
+    if (!table) throw new Error("Literature table not found");
+    if (table.userId !== userId) throw new Error("Not authorized to save this literature table");
+
+    await assertCanEditNotebook(ctx, table.notebookId, userId);
+
+    const now = Date.now();
+    await ctx.db.patch(args.tableId, {
+      title: args.title,
+      columns: args.columns,
+      papers: args.papers,
+      updatedAt: now,
+    });
+
+    const citationTitles = new Map<Id<"citations">, string>();
+    for (const paper of args.papers) {
+      const citation = await ctx.db.get(paper.citationId);
+      if (citation?.title) {
+        citationTitles.set(paper.citationId, citation.title);
+      }
+    }
+
+    const csv = literatureTableToCsv(args.columns, args.papers, citationTitles);
+
+    const existingSavedSpreadsheets = await ctx.db
+      .query("spreadsheets")
+      .withIndex("by_notebook_and_user", (q) =>
+        q.eq("notebookId", table.notebookId).eq("userId", userId)
+      )
+      .collect();
+    const existing = existingSavedSpreadsheets.find(
+      (saved) => saved.metadata?.sourceLiteratureTableId === args.tableId
+    );
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        title: args.title,
+        data: csv,
+        status: "completed",
+        metadata: {
+          ...existing.metadata,
+          spreadsheetType: "literature_review",
+          sourceLiteratureTableId: args.tableId,
+        },
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("spreadsheets", {
+      userId,
+      notebookId: table.notebookId,
+      title: args.title,
+      data: csv,
+      status: "completed",
+      metadata: {
+        spreadsheetType: "literature_review",
+        sourceLiteratureTableId: args.tableId,
       },
       createdAt: now,
       updatedAt: now,

--- a/convex/studio/literature_tables/literatureTableCsv.ts
+++ b/convex/studio/literature_tables/literatureTableCsv.ts
@@ -1,0 +1,49 @@
+import type { Doc, Id } from "../../_generated/dataModel";
+
+const SYSTEM_COLUMN_TYPES = new Set(["paper_title", "authors", "year", "study_type"]);
+
+type LiteratureTableColumn = Doc<"literatureTables">["columns"][number];
+type LiteratureTablePaper = Doc<"literatureTables">["papers"][number];
+
+function isDataColumn(col: LiteratureTableColumn): boolean {
+  return col.isVisible && !SYSTEM_COLUMN_TYPES.has(col.type);
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function getPaperTitle(
+  paper: LiteratureTablePaper,
+  columns: LiteratureTableColumn[],
+  citationTitle?: string
+): string {
+  if (citationTitle?.trim()) return citationTitle;
+  const titleCol = columns.find((col) => col.type === "paper_title");
+  if (titleCol && paper.rowData[titleCol.id]) return paper.rowData[titleCol.id];
+  return "Untitled Paper";
+}
+
+export function literatureTableToCsv(
+  columns: LiteratureTableColumn[],
+  papers: LiteratureTablePaper[],
+  citationTitles: Map<Id<"citations">, string>
+): string {
+  const dataColumns = columns.filter(isDataColumn).toSorted((a, b) => a.order - b.order);
+  const headers = ["Paper", ...dataColumns.map((col) => col.name)];
+
+  const rows = papers
+    .filter((paper) => paper.isIncluded)
+    .map((paper) => {
+      const title = getPaperTitle(paper, columns, citationTitles.get(paper.citationId));
+      const values = dataColumns.map((col) => paper.rowData[col.id] || "");
+      return [title, ...values];
+    });
+
+  return [headers.map(escapeCSV).join(","), ...rows.map((row) => row.map(escapeCSV).join(","))].join(
+    "\n"
+  );
+}

--- a/convex/studio/literature_tables/literatureTableCsv.ts
+++ b/convex/studio/literature_tables/literatureTableCsv.ts
@@ -43,7 +43,8 @@ export function literatureTableToCsv(
       return [title, ...values];
     });
 
-  return [headers.map(escapeCSV).join(","), ...rows.map((row) => row.map(escapeCSV).join(","))].join(
-    "\n"
-  );
+  return [
+    headers.map(escapeCSV).join(","),
+    ...rows.map((row) => row.map(escapeCSV).join(",")),
+  ].join("\n");
 }


### PR DESCRIPTION
## Summary

- Fix literature report toolbar for narrow panels: always-visible icon actions, combined export dropdown (PDF + Markdown), and portaled `DropdownMenu` so menus are not clipped by overflow-hidden parents.
- Label saved literature review reports correctly in Studio (`Literature Review` subtitle + `BookOpen` icon matching landing page styling).
- Wire up **Save table** for literature tables: persists column/row edits and saves a Studio spreadsheet copy, then opens it in the panel.

## Test plan

- [ ] Open a literature report in the studio side panel; confirm Copy, Export dropdown, Save & Edit, and Close are visible at ~600px width.
- [ ] Click Export dropdown; confirm PDF and Markdown options appear and work.
- [ ] Save a literature report to Studio; confirm note shows `Literature Review` label and orange book icon.
- [ ] Open a literature table, edit columns, click Save table; confirm toast, spreadsheet appears in Studio list, and content matches.
- [ ] Re-save the same table; confirm existing spreadsheet updates instead of duplicating.
- [x] `bun run typecheck:web` + `typecheck:convex` pass
- [x] `bun run test:convex -- convex/studio/literature_tables/index.test.ts` passes

Made with [Cursor](https://cursor.com)