### PR TITLE
feat(studio): slim note list payloads and unify structured LLM output

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -343,12 +343,15 @@ const AppContent: React.FC = () => {
     () => ({
       notes: chatStream.displayNotes,
       onUpdateNote: noteCRUD.handleUpdateNote,
-      onUpdateNoteFull: noteCRUD.handleUpdateNoteFull,
-      onDeleteNote: noteCRUD.handleDeleteNote,
-      onAddNote: noteCRUD.handleAddNote,
+      onUpdateNoteFull: chatStream.updatePendingStudioNote,
+      onDeleteNote: async (id: string) => {
+        chatStream.removePendingStudioNote(id);
+        await noteCRUD.handleDeleteNote(id);
+      },
+      onAddNote: chatStream.addPendingStudioNote,
       onSaveReportContent: noteCRUD.handleSaveReportContent,
     }),
-    [chatStream.displayNotes, noteCRUD]
+    [chatStream, noteCRUD]
   );
 
   return (

--- a/apps/web/src/features/chat/hooks/useChatStream.ts
+++ b/apps/web/src/features/chat/hooks/useChatStream.ts
@@ -3,6 +3,10 @@ import { type Doc, Id } from "@convex/_generated/dataModel";
 import { useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  mergePendingStudioNotes,
+  prunePendingStudioNotes,
+} from "@/features/studio/utils/mergePendingStudioNotes";
+import {
   AgentGroundingCheck,
   ChatActivityPhase,
   ChatAgentTrace,
@@ -19,10 +23,6 @@ import {
   useSourceSuggestions,
 } from "../services/chatApi";
 import { useStartDeepResearch } from "../services/researchApi";
-import {
-  mergePendingStudioNotes,
-  prunePendingStudioNotes,
-} from "@/features/studio/utils/mergePendingStudioNotes";
 import {
   computeRemoteGenerationBlocksSend,
   researchProgressToStreamingActivity,
@@ -117,12 +117,8 @@ export function useChatStream({
 
   const displayNotes = useMemo(() => {
     const overlayNotebook = studioListOverlay.notebookId;
-    const pending =
-      overlayNotebook === activeNotebookId ? studioListOverlay.pending : [];
-    const withPending = mergePendingStudioNotes(
-      notes,
-      prunePendingStudioNotes(notes, pending)
-    );
+    const pending = overlayNotebook === activeNotebookId ? studioListOverlay.pending : [];
+    const withPending = mergePendingStudioNotes(notes, prunePendingStudioNotes(notes, pending));
     if (studioListOverlay.savedChat && overlayNotebook === activeNotebookId) {
       return [studioListOverlay.savedChat, ...withPending];
     }
@@ -213,7 +209,7 @@ export function useChatStream({
       // Only auto-release if:
       // 1. Generation is old (>5 min)
       // 2. We're not actively streaming locally
-      // 3. There's no assistant message waiting for this generation
+      // 3. Last message is already an assistant (generation lock stuck after persist)
       const last = messages[messages.length - 1];
       const isWaitingForAssistant = last?.role !== "assistant";
 

--- a/apps/web/src/features/chat/hooks/useChatStream.ts
+++ b/apps/web/src/features/chat/hooks/useChatStream.ts
@@ -20,9 +20,19 @@ import {
 } from "../services/chatApi";
 import { useStartDeepResearch } from "../services/researchApi";
 import {
+  mergePendingStudioNotes,
+  prunePendingStudioNotes,
+} from "@/features/studio/utils/mergePendingStudioNotes";
+import {
   computeRemoteGenerationBlocksSend,
   researchProgressToStreamingActivity,
 } from "../utils/chatStreamHelpers";
+
+type StudioListOverlayState = {
+  notebookId: string | null;
+  pending: Note[];
+  savedChat: Note | null;
+};
 
 interface UseChatStreamProps {
   activeNotebookId: string | null;
@@ -99,14 +109,69 @@ export function useChatStream({
   const streamStartedAtRef = useRef<number | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  const [optimisticSaveNote, setOptimisticSaveNote] = useState<{
-    notebookId: string;
-    note: Note;
-  } | null>(null);
+  const [studioListOverlay, setStudioListOverlay] = useState<StudioListOverlayState>({
+    notebookId: null,
+    pending: [],
+    savedChat: null,
+  });
+
   const displayNotes = useMemo(() => {
-    if (!optimisticSaveNote || optimisticSaveNote.notebookId !== activeNotebookId) return notes;
-    return [optimisticSaveNote.note, ...notes];
-  }, [notes, optimisticSaveNote, activeNotebookId]);
+    const overlayNotebook = studioListOverlay.notebookId;
+    const pending =
+      overlayNotebook === activeNotebookId ? studioListOverlay.pending : [];
+    const withPending = mergePendingStudioNotes(
+      notes,
+      prunePendingStudioNotes(notes, pending)
+    );
+    if (studioListOverlay.savedChat && overlayNotebook === activeNotebookId) {
+      return [studioListOverlay.savedChat, ...withPending];
+    }
+    return withPending;
+  }, [notes, studioListOverlay, activeNotebookId]);
+
+  const addPendingStudioNote = useCallback(
+    (note: Note) => {
+      if (!activeNotebookId) return;
+      setStudioListOverlay((prev) => {
+        const basePending = prev.notebookId === activeNotebookId ? prev.pending : [];
+        return {
+          notebookId: activeNotebookId,
+          pending: [note, ...prunePendingStudioNotes(notes, basePending)],
+          savedChat: prev.notebookId === activeNotebookId ? prev.savedChat : null,
+        };
+      });
+    },
+    [activeNotebookId, notes]
+  );
+
+  const updatePendingStudioNote = useCallback((placeholderId: string, note: Note) => {
+    setStudioListOverlay((prev) => ({
+      ...prev,
+      pending: prev.pending.map((pending) => (pending.id === placeholderId ? note : pending)),
+    }));
+  }, []);
+
+  const removePendingStudioNote = useCallback((id: string) => {
+    setStudioListOverlay((prev) => ({
+      ...prev,
+      pending: prev.pending.filter((note) => note.id !== id),
+    }));
+  }, []);
+
+  const setOptimisticSaveNote = useCallback(
+    (payload: { notebookId: string; note: Note } | null) => {
+      if (payload === null) {
+        setStudioListOverlay((prev) => ({ ...prev, savedChat: null }));
+        return;
+      }
+      setStudioListOverlay((prev) => ({
+        notebookId: payload.notebookId,
+        pending: prev.notebookId === payload.notebookId ? prev.pending : [],
+        savedChat: payload.note,
+      }));
+    },
+    []
+  );
 
   const resetStreamingState = useCallback(() => {
     setIsChatStreaming(false);
@@ -752,6 +817,9 @@ export function useChatStream({
     remoteChatGenerating: chatRemoteGenerating,
     remoteGenerationBlocksSend,
     displayNotes,
+    addPendingStudioNote,
+    updatePendingStudioNote,
+    removePendingStudioNote,
     handleSendMessage,
     handleClearChatHistory,
     setMessageFeedback,

--- a/apps/web/src/features/studio/components/StudioPanel.tsx
+++ b/apps/web/src/features/studio/components/StudioPanel.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { MiniAudioPlayer } from "@/features/audio/components/MiniAudioPlayer";
 import { useAudioPlayerContext } from "@/features/audio/useAudioPlayer";
@@ -11,6 +12,7 @@ import {
 import { useConfirmDialog } from "@/shared/ui/useConfirmDialog";
 import { useNoteActions } from "../hooks/useNoteActions";
 import { useStudioHandlers } from "../hooks/useStudioHandlers";
+import { useNoteDetail } from "../services/notesApi";
 import { useStudioContext } from "../useStudioContext";
 import { ActiveNoteView } from "./ActiveNoteView";
 import { CustomizeAudioModal } from "./CustomizeAudioModal";
@@ -72,8 +74,14 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
   const [isInfographicFullscreen, setIsInfographicFullscreen] = useState(false);
   const infographicControlsRef = useRef<InfographicViewControls | null>(null);
 
-  // Derived state
-  const activeNote = notes.find((n) => n.id === activeNoteId) || null;
+  // Derived state — list rows are summaries; load full content when opening a saved note.
+  const listNote = notes.find((n) => n.id === activeNoteId) ?? null;
+  const shouldLoadFullNote = Boolean(listNote && listNote.status !== "generating");
+  const { note: fetchedNote, isLoading: isLoadingFullNote } = useNoteDetail(
+    shouldLoadFullNote ? listNote!.type : null,
+    shouldLoadFullNote ? activeNoteId : null
+  );
+  const activeNote = fetchedNote ?? listNote;
 
   const expandedSameNoteHidesMini =
     isOpen &&
@@ -316,6 +324,12 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
           className={`flex-1 w-full relative ${showDockedMiniPlayer ? "overflow-hidden" : "overflow-y-auto"}`}
         >
           {activeNote ? (
+            isLoadingFullNote ? (
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden />
+                <span className="sr-only">Loading note…</span>
+              </div>
+            ) : (
             <ActiveNoteView
               activeNote={activeNote}
               isMindMapExpanded={isMindMapExpanded}
@@ -329,6 +343,7 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
               registerInfographicControls={handleInfographicControlsRegister}
               onInfographicFullscreenChange={setIsInfographicFullscreen}
             />
+            )
           ) : (
             <NoteListView
               tools={tools}

--- a/apps/web/src/features/studio/components/StudioPanel.tsx
+++ b/apps/web/src/features/studio/components/StudioPanel.tsx
@@ -81,7 +81,16 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
     shouldLoadFullNote ? listNote!.type : null,
     shouldLoadFullNote ? activeNoteId : null
   );
-  const activeNote = fetchedNote ?? listNote;
+  const detailLoadFailed = shouldLoadFullNote && !isLoadingFullNote && fetchedNote === null;
+  const activeNote = fetchedNote ?? (shouldLoadFullNote ? null : listNote);
+  const headerNote = listNote ?? fetchedNote;
+
+  useEffect(() => {
+    if (detailLoadFailed) {
+      setActiveNoteId(null);
+      setIsEditingReportContent(false);
+    }
+  }, [detailLoadFailed]);
 
   const expandedSameNoteHidesMini =
     isOpen &&
@@ -291,7 +300,7 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
 
         {/* Header */}
         <StudioPanelHeader
-          activeNote={activeNote}
+          activeNote={activeNoteId ? headerNote : null}
           onBack={handleBack}
           onClose={onClose}
           editingId={noteActions.editingId}
@@ -323,26 +332,26 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({
         <div
           className={`flex-1 w-full relative ${showDockedMiniPlayer ? "overflow-hidden" : "overflow-y-auto"}`}
         >
-          {activeNote ? (
-            isLoadingFullNote ? (
+          {activeNoteId ? (
+            isLoadingFullNote || !activeNote ? (
               <div className="flex h-full items-center justify-center text-muted-foreground">
                 <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden />
                 <span className="sr-only">Loading note…</span>
               </div>
             ) : (
-            <ActiveNoteView
-              activeNote={activeNote}
-              isMindMapExpanded={isMindMapExpanded}
-              onToggleMindMap={() => setIsMindMapExpanded(!isMindMapExpanded)}
-              onUpdateNoteFull={onUpdateNoteFull}
-              isMobile={isMobile}
-              onBack={handleBack}
-              isEditingReportContent={isEditingReportContent}
-              onSaveReportContent={handleSaveReportContent}
-              onCancelEditReport={handleCancelEditReport}
-              registerInfographicControls={handleInfographicControlsRegister}
-              onInfographicFullscreenChange={setIsInfographicFullscreen}
-            />
+              <ActiveNoteView
+                activeNote={activeNote}
+                isMindMapExpanded={isMindMapExpanded}
+                onToggleMindMap={() => setIsMindMapExpanded(!isMindMapExpanded)}
+                onUpdateNoteFull={onUpdateNoteFull}
+                isMobile={isMobile}
+                onBack={handleBack}
+                isEditingReportContent={isEditingReportContent}
+                onSaveReportContent={handleSaveReportContent}
+                onCancelEditReport={handleCancelEditReport}
+                registerInfographicControls={handleInfographicControlsRegister}
+                onInfographicFullscreenChange={setIsInfographicFullscreen}
+              />
             )
           ) : (
             <NoteListView

--- a/apps/web/src/features/studio/hooks/useNoteCRUD.ts
+++ b/apps/web/src/features/studio/hooks/useNoteCRUD.ts
@@ -135,16 +135,10 @@ export function useNoteCRUD({ activeNotebookId }: UseNoteCRUDProps) {
     [updateReport]
   );
 
-  const handleUpdateNoteFull = useCallback((_id: string, _note: Note) => undefined, []);
-
-  const handleAddNote = useCallback((_note: Note) => undefined, []);
-
   return {
     notes,
     handleUpdateNote,
     handleDeleteNote,
-    handleUpdateNoteFull,
-    handleAddNote,
     handleSaveReportContent,
   };
 }

--- a/apps/web/src/features/studio/services/notesApi.test.ts
+++ b/apps/web/src/features/studio/services/notesApi.test.ts
@@ -138,6 +138,19 @@ describe("mapDatabaseNoteToNote", () => {
     }
   });
 
+  it("maps spreadsheet preview from data_extraction metadata", () => {
+    const result = mapDatabaseNoteToNote({
+      ...baseNote,
+      _type: "spreadsheet",
+      data: "a,b\n1,2",
+      metadata: { spreadsheetType: "data_extraction" },
+    });
+    expect(result.preview).toBe("Spreadsheet · Data Table");
+    if (result.type === "spreadsheet") {
+      expect(result.metadata.spreadsheetType).toBe("data_extraction");
+    }
+  });
+
   it("maps spreadsheet type with object data", () => {
     const result = mapDatabaseNoteToNote({
       ...baseNote,

--- a/apps/web/src/features/studio/services/notesApi.test.ts
+++ b/apps/web/src/features/studio/services/notesApi.test.ts
@@ -231,4 +231,61 @@ describe("mapDatabaseNoteToNote", () => {
       expect(result.metadata.cardCount).toBe(0);
     }
   });
+
+  it("maps flashcard list summary using _cardsCount when cardsData is stripped", () => {
+    const result = mapDatabaseNoteToNote({
+      ...baseNote,
+      _type: "flashcard",
+      _cardsCount: 12,
+      metadata: { difficulty: "hard" },
+    });
+    expect(result.type).toBe("flashcard");
+    if (result.type === "flashcard") {
+      expect(result.flashcards).toEqual([]);
+      expect(result.metadata.cardCount).toBe(12);
+      expect(result.preview).toBe("12 Flashcards · Hard");
+    }
+  });
+
+  it("maps quiz list summary using _questionsCount when questionsData is stripped", () => {
+    const result = mapDatabaseNoteToNote({
+      ...baseNote,
+      _type: "quiz",
+      _questionsCount: 5,
+      metadata: { difficulty: "easy" },
+    });
+    expect(result.type).toBe("quiz");
+    if (result.type === "quiz") {
+      expect(result.questions).toEqual([]);
+      expect(result.metadata.questionCount).toBe(5);
+      expect(result.preview).toContain("5");
+    }
+  });
+
+  it("maps infographic list summary using _imageUrl when data is stripped", () => {
+    const result = mapDatabaseNoteToNote({
+      ...baseNote,
+      _type: "infographic",
+      _imageUrl: "https://cdn.example.com/thumb.png",
+    });
+    expect(result.type).toBe("infographic");
+    if (result.type === "infographic") {
+      expect(result.imageUrl).toBe("https://cdn.example.com/thumb.png");
+      expect(result.preview).toBe("Infographic");
+    }
+  });
+
+  it("maps written questions list summary using _questionsCount", () => {
+    const result = mapDatabaseNoteToNote({
+      ...baseNote,
+      _type: "writtenQuestions",
+      _questionsCount: 3,
+      questionType: "essay",
+    });
+    expect(result.type).toBe("writtenQuestions");
+    if (result.type === "writtenQuestions") {
+      expect(result.questions).toEqual([]);
+      expect(result.metadata.questionCount).toBe(3);
+    }
+  });
 });

--- a/apps/web/src/features/studio/services/notesApi.ts
+++ b/apps/web/src/features/studio/services/notesApi.ts
@@ -6,6 +6,12 @@ import { getReportSubtitle, normalizeReportTypeId } from "@/shared/types/reportT
 import { pickStudioGenerationFields } from "../utils/studioGenerationLabels";
 import { getSpreadsheetTypeLabel } from "./spreadsheetsApi";
 
+function arrayCount(data: unknown, summaryCount: unknown): number {
+  if (Array.isArray(data)) return data.length;
+  if (typeof summaryCount === "number" && Number.isFinite(summaryCount)) return summaryCount;
+  return 0;
+}
+
 function normalizeMindMapNodeData(rawData: any, fallbackTitle: string) {
   const maybeWrapped = rawData?.nodeData?.nodeData ?? rawData?.nodeData ?? rawData;
   const normalized = maybeWrapped && typeof maybeWrapped === "object" ? { ...maybeWrapped } : {};
@@ -44,7 +50,8 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         },
       };
 
-    case "flashcard":
+    case "flashcard": {
+      const cardCount = arrayCount(dbNote.cardsData, dbNote._cardsCount);
       return {
         id: dbNote._id,
         title: dbNote.title,
@@ -54,14 +61,16 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         status: dbNote.status,
         metadata: {
           difficulty: dbNote.metadata?.difficulty || "medium",
-          cardCount: dbNote.cardsData?.length || 0,
+          cardCount,
           topic: dbNote.metadata?.topic,
           error: dbNote.metadata?.error,
           ...pickStudioGenerationFields(dbNote.metadata),
         },
       };
+    }
 
-    case "quiz":
+    case "quiz": {
+      const questionCount = arrayCount(dbNote.questionsData, dbNote._questionsCount);
       return {
         id: dbNote._id,
         title: dbNote.title,
@@ -70,13 +79,14 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         questions: dbNote.questionsData || [],
         status: dbNote.status,
         metadata: {
-          questionCount: dbNote.questionsData?.length || 0,
+          questionCount,
           difficulty: dbNote.metadata?.difficulty || "medium",
           focusArea: dbNote.metadata?.focusArea,
           error: dbNote.metadata?.error,
           ...pickStudioGenerationFields(dbNote.metadata),
         },
       };
+    }
 
     case "mindmap": {
       const nodeData = normalizeMindMapNodeData(dbNote.data, dbNote.title);
@@ -113,7 +123,7 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         title: dbNote.title,
         preview: getInfographicPreview(dbNote),
         type: "infographic",
-        imageUrl: dbNote.data?.imageUrl || "",
+        imageUrl: dbNote.data?.imageUrl || dbNote._imageUrl || "",
         prompt: dbNote.data?.prompt || "",
         status: dbNote.status,
         metadata: {
@@ -145,7 +155,8 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         },
       };
 
-    case "writtenQuestions":
+    case "writtenQuestions": {
+      const questionCount = arrayCount(dbNote.questionsData, dbNote._questionsCount);
       return {
         id: dbNote._id,
         title: dbNote.title,
@@ -154,7 +165,7 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
         questions: dbNote.questionsData || [],
         status: dbNote.status,
         metadata: {
-          questionCount: dbNote.questionsData?.length || 0,
+          questionCount,
           difficulty: dbNote.metadata?.difficulty || "medium",
           questionType: dbNote.questionType || "short",
           focusArea: dbNote.metadata?.focusArea,
@@ -163,6 +174,7 @@ export function mapDatabaseNoteToNote(dbNote: any): Note {
           ...pickStudioGenerationFields(dbNote.metadata),
         },
       };
+    }
 
     case "note":
       return {
@@ -206,7 +218,7 @@ function getReportPreview(dbNote: any): string {
 }
 
 function getFlashcardPreview(dbNote: any): string {
-  const count = dbNote.cardsData?.length || 0;
+  const count = arrayCount(dbNote.cardsData, dbNote._cardsCount);
   const difficulty = capitalizeDifficulty(dbNote.metadata?.difficulty);
   if (dbNote.status === "generating")
     return `${count} Flashcard${count !== 1 ? "s" : ""} · ${difficulty}`;
@@ -215,7 +227,7 @@ function getFlashcardPreview(dbNote: any): string {
 }
 
 function getQuizPreview(dbNote: any): string {
-  const count = dbNote.questionsData?.length || 0;
+  const count = arrayCount(dbNote.questionsData, dbNote._questionsCount);
   const difficulty = capitalizeDifficulty(dbNote.metadata?.difficulty);
   if (dbNote.status === "generating")
     return `${count} Question${count !== 1 ? "s" : ""} · ${difficulty}`;
@@ -265,7 +277,7 @@ function getSpreadsheetPreview(dbNote: any): string {
 }
 
 function getWrittenQuestionsPreview(dbNote: any): string {
-  const count = dbNote.questionsData?.length || 0;
+  const count = arrayCount(dbNote.questionsData, dbNote._questionsCount);
   const difficulty = capitalizeDifficulty(dbNote.metadata?.difficulty);
   if (dbNote.status === "generating")
     return `${count} Question${count !== 1 ? "s" : ""} · ${difficulty}`;
@@ -311,11 +323,25 @@ export function useNoteCounts(notebookId: string | null) {
 }
 
 /**
- * Get a single note by type and ID
+ * Get a single note by type and ID (full payload).
  */
 export function useNote(type: string, noteId: string | null) {
   const note = useQuery(api.notes.index.get, noteId && type ? { type, id: noteId as any } : "skip");
   return note ? mapDatabaseNoteToNote(note) : null;
+}
+
+/**
+ * Load full studio note content when opening a saved item from the list.
+ */
+export function useNoteDetail(type: string | null, noteId: string | null) {
+  const note = useQuery(
+    api.notes.index.get,
+    type && noteId ? { type, id: noteId as any } : "skip"
+  );
+  return {
+    note: note ? mapDatabaseNoteToNote(note) : null,
+    isLoading: note === undefined && Boolean(type && noteId),
+  };
 }
 
 /**

--- a/apps/web/src/features/studio/services/notesApi.ts
+++ b/apps/web/src/features/studio/services/notesApi.ts
@@ -334,10 +334,7 @@ export function useNote(type: string, noteId: string | null) {
  * Load full studio note content when opening a saved item from the list.
  */
 export function useNoteDetail(type: string | null, noteId: string | null) {
-  const note = useQuery(
-    api.notes.index.get,
-    type && noteId ? { type, id: noteId as any } : "skip"
-  );
+  const note = useQuery(api.notes.index.get, type && noteId ? { type, id: noteId as any } : "skip");
   return {
     note: note ? mapDatabaseNoteToNote(note) : null,
     isLoading: note === undefined && Boolean(type && noteId),

--- a/apps/web/src/features/studio/utils/mergePendingStudioNotes.test.ts
+++ b/apps/web/src/features/studio/utils/mergePendingStudioNotes.test.ts
@@ -36,10 +36,7 @@ describe("mergePendingStudioNotes", () => {
 describe("prunePendingStudioNotes", () => {
   it("removes pending rows once the query includes the same id", () => {
     const queryNotes = [report("real-id", "Report")];
-    const pendingNotes = [
-      report("placeholder", "Report"),
-      report("real-id", "Report"),
-    ];
+    const pendingNotes = [report("placeholder", "Report"), report("real-id", "Report")];
 
     expect(prunePendingStudioNotes(queryNotes, pendingNotes)).toEqual([
       report("placeholder", "Report"),

--- a/apps/web/src/features/studio/utils/mergePendingStudioNotes.test.ts
+++ b/apps/web/src/features/studio/utils/mergePendingStudioNotes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Note } from "@/shared/types/index";
+import { mergePendingStudioNotes, prunePendingStudioNotes } from "./mergePendingStudioNotes";
+
+const report = (id: string, title: string): Note => ({
+  id,
+  title,
+  preview: "Report",
+  type: "report",
+  content: "",
+  status: "generating",
+  metadata: { reportType: "summary", documentIds: [] },
+});
+
+describe("mergePendingStudioNotes", () => {
+  it("prepends pending notes that are not yet in the query", () => {
+    const queryNotes = [report("server-1", "Existing")];
+    const pendingNotes = [report("pending-1", "Starting report")];
+
+    expect(mergePendingStudioNotes(queryNotes, pendingNotes)).toEqual([
+      report("pending-1", "Starting report"),
+      report("server-1", "Existing"),
+    ]);
+  });
+
+  it("prefers query rows when ids overlap", () => {
+    const queryNotes = [report("shared", "From server")];
+    const pendingNotes = [report("shared", "Optimistic copy")];
+
+    expect(mergePendingStudioNotes(queryNotes, pendingNotes)).toEqual([
+      report("shared", "From server"),
+    ]);
+  });
+});
+
+describe("prunePendingStudioNotes", () => {
+  it("removes pending rows once the query includes the same id", () => {
+    const queryNotes = [report("real-id", "Report")];
+    const pendingNotes = [
+      report("placeholder", "Report"),
+      report("real-id", "Report"),
+    ];
+
+    expect(prunePendingStudioNotes(queryNotes, pendingNotes)).toEqual([
+      report("placeholder", "Report"),
+    ]);
+  });
+});

--- a/apps/web/src/features/studio/utils/mergePendingStudioNotes.ts
+++ b/apps/web/src/features/studio/utils/mergePendingStudioNotes.ts
@@ -1,0 +1,19 @@
+import type { Note } from "@/shared/types/index";
+
+/**
+ * Merge optimistic pending studio notes with server-backed notes.
+ * Pending entries appear first; server rows win when ids overlap.
+ */
+export function mergePendingStudioNotes(queryNotes: Note[], pendingNotes: Note[]): Note[] {
+  const queryIds = new Set(queryNotes.map((note) => note.id));
+  const pendingOnly = pendingNotes.filter((note) => !queryIds.has(note.id));
+  return [...pendingOnly, ...queryNotes];
+}
+
+/**
+ * Drop pending placeholders once the unified query includes the same id.
+ */
+export function prunePendingStudioNotes(queryNotes: Note[], pendingNotes: Note[]): Note[] {
+  const queryIds = new Set(queryNotes.map((note) => note.id));
+  return pendingNotes.filter((note) => !queryIds.has(note.id));
+}

--- a/convex/_agents/_shared/structuredLlm.test.ts
+++ b/convex/_agents/_shared/structuredLlm.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { invokeStructuredOutput } from "./structuredLlm.js";
+
+const uncachedLlmCall = vi.fn();
+
+vi.mock("./cachedLlm.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./cachedLlm.js")>();
+  return {
+    ...actual,
+    uncachedLlmCall: (...args: Parameters<typeof actual.uncachedLlmCall>) =>
+      uncachedLlmCall(...args),
+  };
+});
+
+const TestSchema = z.object({
+  topics: z.array(z.string()).min(1),
+  summary: z.string().min(10),
+});
+
+const validPayload = JSON.stringify({
+  topics: ["A"],
+  summary: "Long enough summary for validation.",
+});
+
+describe("invokeStructuredOutput", () => {
+  beforeEach(() => {
+    uncachedLlmCall.mockReset();
+  });
+
+  it("parses valid JSON from structuredJson", async () => {
+    uncachedLlmCall.mockResolvedValueOnce({
+      content: "",
+      structuredJson: validPayload,
+    });
+
+    const result = await invokeStructuredOutput({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      schema: TestSchema,
+      schemaName: "test_schema",
+    });
+
+    expect(result.topics).toEqual(["A"]);
+    expect(uncachedLlmCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses json_object on final attempt after empty payloads", async () => {
+    uncachedLlmCall
+      .mockResolvedValueOnce({ content: "", structuredJson: "" })
+      .mockResolvedValueOnce({ content: "", structuredJson: "" })
+      .mockResolvedValueOnce({ content: "", structuredJson: validPayload });
+
+    await invokeStructuredOutput({
+      systemPrompt: "sys",
+      userPrompt: "user",
+      schema: TestSchema,
+      schemaName: "test_schema",
+    });
+
+    const formats = uncachedLlmCall.mock.calls.map(
+      (call) => call[0]?.responseFormat as { type: string } | undefined
+    );
+    expect(formats[2]?.type).toBe("json_object");
+  });
+});

--- a/convex/_agents/_shared/structuredLlm.ts
+++ b/convex/_agents/_shared/structuredLlm.ts
@@ -1,0 +1,126 @@
+"use node";
+
+import { z } from "zod";
+import { env } from "../../_lib/env";
+import { extractJsonObjectString, uncachedLlmCall } from "./cachedLlm.js";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const JSON_REMINDER =
+  "\n\nREMINDER: Output ONLY a single valid JSON object. No commentary, planning text, or markdown outside the JSON.";
+
+export type InvokeStructuredOutputOptions<T> = {
+  systemPrompt: string;
+  userPrompt: string;
+  schema: z.ZodType<T>;
+  schemaName: string;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  /** Default false — GPT-OSS map/structured phases should disable reasoning. */
+  reasoningEnabled?: boolean;
+  maxAttempts?: number;
+  /** Prefix for retry / fallback log lines (e.g. `WrittenQuestionsMap`). */
+  logPrefix?: string;
+};
+
+function parseStructuredContent<T>(raw: string, schema: z.ZodType<T>): T {
+  const trimmed = extractJsonObjectString(raw) ?? raw.trim();
+  if (!trimmed) {
+    throw new Error("empty LLM content");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse structured JSON: ${message}`);
+  }
+
+  const validated = schema.safeParse(parsed);
+  if (!validated.success) {
+    throw new Error(`Structured output validation failed: ${validated.error.message}`);
+  }
+
+  return validated.data;
+}
+
+function isRetriableStructuredError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("empty llm content") ||
+    message.includes("failed to parse structured json") ||
+    message.includes("structured output validation failed") ||
+    message.includes("no json payload for structured response")
+  );
+}
+
+/**
+ * Structured output via Together `json_schema` (not LangChain tool calling).
+ * Handles GPT-OSS models that return JSON in `reasoning` when `content` is empty.
+ * Up to 3 attempts with exponential backoff; final attempt falls back to `json_object`.
+ */
+export async function invokeStructuredOutput<T>(
+  options: InvokeStructuredOutputOptions<T>
+): Promise<T> {
+  const model = options.model ?? env.FAST_LLM;
+  const maxTokens = options.maxTokens ?? 16_384;
+  const temperature = options.temperature ?? 0.3;
+  const reasoningEnabled = options.reasoningEnabled ?? false;
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const logPrefix = options.logPrefix ?? "StructuredOutput";
+  const jsonSchema = z.toJSONSchema(options.schema) as Record<string, unknown>;
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const isLastAttempt = attempt === maxAttempts - 1;
+      if (isLastAttempt && attempt > 0) {
+        console.warn(
+          `[${logPrefix}] Structured output attempt ${attempt + 1}/${maxAttempts} using json_object fallback`
+        );
+      }
+
+      const userPrompt = attempt === 0 ? options.userPrompt : `${options.userPrompt}${JSON_REMINDER}`;
+
+      const response = await uncachedLlmCall({
+        model,
+        messages: [
+          { role: "system", content: options.systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature,
+        maxTokens,
+        reasoningEnabled,
+        responseFormat: isLastAttempt
+          ? { type: "json_object" }
+          : {
+              type: "json_schema",
+              json_schema: {
+                name: options.schemaName,
+                schema: jsonSchema,
+              },
+            },
+      });
+
+      const jsonPayload =
+        response.structuredJson?.trim() || extractJsonObjectString(response.content) || "";
+      return parseStructuredContent(jsonPayload, options.schema);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < maxAttempts - 1 && isRetriableStructuredError(error)) {
+        const delayMs = 1000 * 2 ** attempt;
+        console.warn(
+          `[${logPrefix}] Structured output retry ${attempt + 1}/${maxAttempts}: ${lastError.message}`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      throw lastError;
+    }
+  }
+
+  throw lastError ?? new Error("Structured output failed");
+}

--- a/convex/_agents/_shared/structuredLlm.ts
+++ b/convex/_agents/_shared/structuredLlm.ts
@@ -59,7 +59,8 @@ function isRetriableStructuredError(error: unknown): boolean {
 /**
  * Structured output via Together `json_schema` (not LangChain tool calling).
  * Handles GPT-OSS models that return JSON in `reasoning` when `content` is empty.
- * Up to 3 attempts with exponential backoff; final attempt falls back to `json_object`.
+ * Retries parse/validation failures up to `maxAttempts` (default 3) with backoff;
+ * the final attempt falls back to `json_object`. Other errors fail immediately.
  */
 export async function invokeStructuredOutput<T>(
   options: InvokeStructuredOutputOptions<T>
@@ -83,7 +84,8 @@ export async function invokeStructuredOutput<T>(
         );
       }
 
-      const userPrompt = attempt === 0 ? options.userPrompt : `${options.userPrompt}${JSON_REMINDER}`;
+      const userPrompt =
+        attempt === 0 ? options.userPrompt : `${options.userPrompt}${JSON_REMINDER}`;
 
       const response = await uncachedLlmCall({
         model,

--- a/convex/_agents/_shared/studioTextLlm.ts
+++ b/convex/_agents/_shared/studioTextLlm.ts
@@ -15,7 +15,7 @@ export type InvokeTogetherTextOptions = {
 
 /**
  * Plain-text LLM call via Together REST (not LangChain).
- * Reads assistant text from `content` or `reasoning` (GPT-OSS hybrid models).
+ * Assistant text via `uncachedLlmCall` (falls back to `reasoning` for GPT-OSS when `content` is empty).
  */
 export async function invokeTogetherText(options: InvokeTogetherTextOptions): Promise<string> {
   const response = await uncachedLlmCall({

--- a/convex/_agents/_shared/studioTextLlm.ts
+++ b/convex/_agents/_shared/studioTextLlm.ts
@@ -1,0 +1,37 @@
+"use node";
+
+import { env } from "../../_lib/env";
+import { uncachedLlmCall } from "./cachedLlm.js";
+
+export type InvokeTogetherTextOptions = {
+  systemPrompt: string;
+  userPrompt: string;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  /** Default false for map phases; true for reduce/synthesis with smart models. */
+  reasoningEnabled?: boolean;
+};
+
+/**
+ * Plain-text LLM call via Together REST (not LangChain).
+ * Reads assistant text from `content` or `reasoning` (GPT-OSS hybrid models).
+ */
+export async function invokeTogetherText(options: InvokeTogetherTextOptions): Promise<string> {
+  const response = await uncachedLlmCall({
+    model: options.model ?? env.FAST_LLM,
+    messages: [
+      { role: "system", content: options.systemPrompt },
+      { role: "user", content: options.userPrompt },
+    ],
+    temperature: options.temperature ?? 0.3,
+    maxTokens: options.maxTokens,
+    reasoningEnabled: options.reasoningEnabled ?? false,
+  });
+
+  const text = response.content.trim();
+  if (!text) {
+    throw new Error("LLM returned empty text response");
+  }
+  return text;
+}

--- a/convex/_agents/flashcard/FlashcardGraph.ts
+++ b/convex/_agents/flashcard/FlashcardGraph.ts
@@ -45,7 +45,10 @@ export class FlashcardGraph {
       modelKwargs: mergeModelKwargs(reduceModel, "smart"),
     });
 
-    this.fastLlmStructured = createStructuredLLM(this.fastLlm, FlashcardArraySchema);
+    this.fastLlmStructured = createStructuredLLM(FlashcardArraySchema, {
+      model: mapModel,
+      temperature: 0.3,
+    });
   }
 
   private estimateTokens(text: string): number {

--- a/convex/_agents/flashcard/collapseReduceLlm.ts
+++ b/convex/_agents/flashcard/collapseReduceLlm.ts
@@ -2,12 +2,10 @@
 
 import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
-
+import { env } from "../../_lib/env.js";
 import { invokeWithRetry, invokeWithTimeout } from "../_shared/index.js";
 import { withLanguageInstruction } from "../_shared/languageInstruction";
 import type { JobLogger } from "../_shared/logging.js";
-
-import { env } from "../../_lib/env.js";
 import { FLASHCARD_CONFIG } from "./config.js";
 import { detectSimilarFlashcards, groupFlashcardsByTopic } from "./flashcardHeuristics.js";
 import { formatFlashcardsAsText } from "./formatFlashcards.js";

--- a/convex/_agents/flashcard/collapseReduceLlm.ts
+++ b/convex/_agents/flashcard/collapseReduceLlm.ts
@@ -7,6 +7,7 @@ import { invokeWithRetry, invokeWithTimeout } from "../_shared/index.js";
 import { withLanguageInstruction } from "../_shared/languageInstruction";
 import type { JobLogger } from "../_shared/logging.js";
 
+import { env } from "../../_lib/env.js";
 import { FLASHCARD_CONFIG } from "./config.js";
 import { detectSimilarFlashcards, groupFlashcardsByTopic } from "./flashcardHeuristics.js";
 import { formatFlashcardsAsText } from "./formatFlashcards.js";
@@ -102,7 +103,12 @@ ${flashcardsText}
 
 Return the condensed flashcards as a JSON array with "front" and "back" fields.`;
 
-  const structuredLlm = createStructuredLLM(deps.smartLlm, FlashcardArraySchema);
+  const reduceModel = (deps.smartLlm as { model?: string }).model ?? env.SMART_LLM;
+  const structuredLlm = createStructuredLLM(FlashcardArraySchema, {
+    model: reduceModel,
+    reasoningEnabled: true,
+    maxTokens: FLASHCARD_CONFIG.REDUCE_MAX_TOKENS,
+  });
   const response = (await invokeWithRetry(
     () =>
       invokeWithTimeout(
@@ -195,7 +201,12 @@ ${flashcardsText}
 
 Return the complete selected flashcards as a JSON array. For each flashcard, include a "topic" field that categorizes the card (e.g., "Definitions", "Processes", "Timeline", "Concepts", etc.). This helps ensure topic diversity.`;
 
-  const structuredLlm = createStructuredLLM(deps.smartLlm, FlashcardArraySchema);
+  const reduceModel = (deps.smartLlm as { model?: string }).model ?? env.SMART_LLM;
+  const structuredLlm = createStructuredLLM(FlashcardArraySchema, {
+    model: reduceModel,
+    reasoningEnabled: true,
+    maxTokens: FLASHCARD_CONFIG.REDUCE_MAX_TOKENS,
+  });
   const response = await invokeWithRetry(
     () =>
       invokeWithTimeout(

--- a/convex/_agents/flashcard/structuredLlm.ts
+++ b/convex/_agents/flashcard/structuredLlm.ts
@@ -1,9 +1,9 @@
 "use node";
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import type { HumanMessage, SystemMessage } from "@langchain/core/messages";
-import { z } from "zod";
-
+import type { z } from "zod";
+import { env } from "../../_lib/env";
+import { invokeStructuredOutput } from "../_shared/structuredLlm.js";
 import type { FlashcardResponse } from "./prompts.js";
 
 export interface FlashcardOutputInvoker {
@@ -13,11 +13,48 @@ export interface FlashcardOutputInvoker {
   ): Promise<FlashcardResponse>;
 }
 
+function promptsFromMessages(messages: Array<SystemMessage | HumanMessage>): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  const systemPrompt = messages
+    .filter((m) => m.getType() === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  const userPrompt = messages
+    .filter((m) => m.getType() === "human")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  return { systemPrompt, userPrompt };
+}
+
 export function createStructuredLLM(
-  llm: ChatTogetherAI,
-  schema: z.ZodTypeAny
+  schema: z.ZodTypeAny,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+    schemaName?: string;
+    reasoningEnabled?: boolean;
+  }
 ): FlashcardOutputInvoker {
-  return llm.withStructuredOutput(schema, {
-    name: "flashcard_array",
-  }) as any;
+  const model = options?.model ?? env.FAST_LLM;
+  const schemaName = options?.schemaName ?? "flashcard_array";
+
+  return {
+    invoke: async (messages) => {
+      const { systemPrompt, userPrompt } = promptsFromMessages(messages);
+      return invokeStructuredOutput({
+        systemPrompt,
+        userPrompt,
+        schema,
+        schemaName,
+        model,
+        maxTokens: options?.maxTokens,
+        temperature: options?.temperature,
+        reasoningEnabled: options?.reasoningEnabled,
+        logPrefix: "FlashcardStructured",
+      }) as Promise<FlashcardResponse>;
+    },
+  };
 }

--- a/convex/_agents/mindmap/MindMapGraph.ts
+++ b/convex/_agents/mindmap/MindMapGraph.ts
@@ -36,9 +36,11 @@ export { packChunks, validateChunks } from "./chunkHelpers.js";
 export class MindMapGraph {
   private fastLlm: ChatTogetherAI;
   private smartLlm: ChatTogetherAI;
+  private readonly mapModel: string;
   private readonly MAX_TOTAL_FAILURES = 5;
 
   constructor(apiKey: string, mapModel: string, reduceModel: string) {
+    this.mapModel = mapModel;
     this.fastLlm = new ChatTogetherAI({
       apiKey,
       model: mapModel,
@@ -58,7 +60,7 @@ export class MindMapGraph {
 
   async mapProcess(state: ChunkStateType): Promise<Partial<OverallStateType> | Send> {
     const deps: MindMapMapProcessDeps = {
-      extractConcepts: (c) => runConceptExtraction(this.fastLlm, c),
+      extractConcepts: (c) => runConceptExtraction(c, { model: this.mapModel }),
       maxTotalFailures: this.MAX_TOTAL_FAILURES,
     };
     return mapProcess(state, deps);

--- a/convex/_agents/mindmap/structuredLlm.ts
+++ b/convex/_agents/mindmap/structuredLlm.ts
@@ -1,11 +1,10 @@
 "use node";
 
-import type { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
-
+import { env } from "../../_lib/env";
 import { invokeWithTimeout } from "../_shared/index.js";
-
+import { invokeStructuredOutput } from "../_shared/structuredLlm.js";
 import { GRAPH_CONFIG } from "./config.js";
 import { MAP_PROMPT, MAP_SYSTEM_PROMPT } from "./prompts.js";
 import type { ConceptExtraction } from "./state.js";
@@ -17,23 +16,45 @@ export const ConceptExtractionSchema = z.object({
 });
 
 /**
- * Typed concept extraction using the fast LLM and structured output.
+ * Typed concept extraction using structured output (Together json_schema).
  */
 export async function extractConcepts(
-  fastLlm: ChatTogetherAI,
-  content: string
+  content: string,
+  options?: { model?: string; language?: string }
 ): Promise<ConceptExtraction> {
-  const structuredLlm = fastLlm.withStructuredOutput<ConceptExtraction>(ConceptExtractionSchema, {
-    name: "concept_extraction",
-  });
-
-  return await invokeWithTimeout(
+  return invokeWithTimeout(
     () =>
-      (structuredLlm as any).invoke([
-        new SystemMessage(MAP_SYSTEM_PROMPT),
-        new HumanMessage(MAP_PROMPT.replace("{content}", content)),
-      ]),
+      invokeStructuredOutput({
+        systemPrompt: MAP_SYSTEM_PROMPT,
+        userPrompt: MAP_PROMPT.replace("{content}", content),
+        schema: ConceptExtractionSchema,
+        schemaName: "concept_extraction",
+        model: options?.model ?? env.FAST_LLM,
+        logPrefix: "MindMapMap",
+      }),
     GRAPH_CONFIG.MAP_TIMEOUT_MS,
     "MindMapMap"
   );
+}
+
+/** @deprecated Use extractConcepts — kept for tests referencing message-style invoke. */
+export async function extractConceptsFromMessages(
+  messages: Array<SystemMessage | HumanMessage>
+): Promise<ConceptExtraction> {
+  const systemPrompt = messages
+    .filter((m) => m.getType() === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  const userPrompt = messages
+    .filter((m) => m.getType() === "human")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+
+  return invokeStructuredOutput({
+    systemPrompt,
+    userPrompt,
+    schema: ConceptExtractionSchema,
+    schemaName: "concept_extraction",
+    logPrefix: "MindMapMap",
+  });
 }

--- a/convex/_agents/quiz/QuizGraph.ts
+++ b/convex/_agents/quiz/QuizGraph.ts
@@ -58,14 +58,19 @@ export class QuizGraph {
     });
 
     this.fastLlmCandidateStructured = createStructuredLLM<QuizCandidateResponse>(
-      this.fastLlm,
       QuizCandidateArraySchema,
-      "quiz_candidates"
+      "quiz_candidates",
+      { model: mapModel, maxTokens: GRAPH_CONFIG.MAP_MAX_TOKENS, temperature: 0.4 }
     );
     this.expandLlmQuestionStructured = createStructuredLLM<QuizQuestion>(
-      this.expandLlm,
       QuizQuestionSchema,
-      "quiz_question_expand"
+      "quiz_question_expand",
+      {
+        model: reduceModel,
+        maxTokens: GRAPH_CONFIG.EXPAND_MAX_TOKENS,
+        temperature: 0.3,
+        reasoningEnabled: true,
+      }
     );
   }
 

--- a/convex/_agents/quiz/nodeReduce.ts
+++ b/convex/_agents/quiz/nodeReduce.ts
@@ -26,7 +26,8 @@ import {
 } from "./prompts.js";
 import { detectSimilarQuestions, heuristicDedupe } from "./quizHeuristics.js";
 import type { OverallStateType } from "./state.js";
-import type { StructuredOutputInvoker } from "./structuredLlm.js";
+import { createStructuredLLM, type StructuredOutputInvoker } from "./structuredLlm.js";
+import { env } from "../../_lib/env.js";
 
 export interface ReduceQuizDeps {
   smartLlm: ChatTogetherAI;
@@ -138,9 +139,11 @@ export async function reduce(
     );
 
     try {
-      const structuredLlm = deps.smartLlm.withStructuredOutput<QuizCandidateIndexSelection>(
+      const reduceModel = (deps.smartLlm as { model?: string }).model ?? env.QUIZ_LLM;
+      const structuredLlm = createStructuredLLM<QuizCandidateIndexSelection>(
         QuizCandidateIndexSelectionSchema,
-        { name: "quiz_candidate_index_selection" }
+        "quiz_candidate_index_selection",
+        { model: reduceModel, reasoningEnabled: true, logPrefix: "QuizReduce" }
       );
 
       const selectionPrompt = getCandidateSelectionPrompt({

--- a/convex/_agents/quiz/nodeReduce.ts
+++ b/convex/_agents/quiz/nodeReduce.ts
@@ -3,7 +3,7 @@
 import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { Send } from "@langchain/langgraph";
-
+import { env } from "../../_lib/env.js";
 import {
   allWithConcurrency,
   invokeWithRetry,
@@ -11,7 +11,6 @@ import {
   withoutMapOutputs,
 } from "../_shared/index.js";
 import { createAgentGraphLogger } from "../_shared/logging.js";
-
 import { GRAPH_CONFIG } from "./config.js";
 import { callStatusUpdate } from "./nodeSplit.js";
 import { expandQuestion, finalizeQuestions } from "./postprocess.js";
@@ -27,7 +26,6 @@ import {
 import { detectSimilarQuestions, heuristicDedupe } from "./quizHeuristics.js";
 import type { OverallStateType } from "./state.js";
 import { createStructuredLLM, type StructuredOutputInvoker } from "./structuredLlm.js";
-import { env } from "../../_lib/env.js";
 
 export interface ReduceQuizDeps {
   smartLlm: ChatTogetherAI;

--- a/convex/_agents/quiz/structuredLlm.ts
+++ b/convex/_agents/quiz/structuredLlm.ts
@@ -1,24 +1,59 @@
 "use node";
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import type { HumanMessage, SystemMessage } from "@langchain/core/messages";
-import { z } from "zod";
+import type { z } from "zod";
+import { env } from "../../_lib/env";
+import { invokeStructuredOutput } from "../_shared/structuredLlm.js";
 
 /**
  * Interface for the structured LLM to avoid deep type instantiation.
- * Follows the pattern from FlashcardGraph.
  */
 export interface StructuredOutputInvoker<T> {
   invoke(messages: Array<SystemMessage | HumanMessage>): Promise<T>;
 }
 
-/**
- * Helper function to create a structured LLM without triggering deep type instantiation.
- */
+function promptsFromMessages(messages: Array<SystemMessage | HumanMessage>): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  const systemPrompt = messages
+    .filter((m) => m.getType() === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  const userPrompt = messages
+    .filter((m) => m.getType() === "human")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  return { systemPrompt, userPrompt };
+}
+
 export function createStructuredLLM<T>(
-  llm: ChatTogetherAI,
   schema: z.ZodTypeAny,
-  name: string
+  name: string,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+    reasoningEnabled?: boolean;
+    logPrefix?: string;
+  }
 ): StructuredOutputInvoker<T> {
-  return llm.withStructuredOutput(schema, { name }) as any;
+  const model = options?.model ?? env.FAST_LLM;
+
+  return {
+    invoke: async (messages) => {
+      const { systemPrompt, userPrompt } = promptsFromMessages(messages);
+      return invokeStructuredOutput({
+        systemPrompt,
+        userPrompt,
+        schema,
+        schemaName: name,
+        model,
+        maxTokens: options?.maxTokens,
+        temperature: options?.temperature,
+        reasoningEnabled: options?.reasoningEnabled,
+        logPrefix: options?.logPrefix ?? "QuizStructured",
+      }) as Promise<T>;
+    },
+  };
 }

--- a/convex/_agents/report/structuredLlm.ts
+++ b/convex/_agents/report/structuredLlm.ts
@@ -3,8 +3,7 @@
 import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import type { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
-import { env } from "../../_lib/env";
-import { extractJsonObjectString, uncachedLlmCall } from "../_shared/cachedLlm.js";
+import { invokeStructuredOutput } from "../_shared/structuredLlm.js";
 
 /**
  * Zod schema for structured map phase output.
@@ -35,8 +34,6 @@ export interface MapOutputInvoker {
 }
 
 const MAP_STRUCTURED_SCHEMA_NAME = "extract_topics_and_summary";
-const MAP_STRUCTURED_MAX_ATTEMPTS = 3;
-const MAP_OUTPUT_JSON_SCHEMA = z.toJSONSchema(MapOutputSchema) as Record<string, unknown>;
 
 export type InvokeMapStructuredOutputOptions = {
   systemPrompt: string;
@@ -46,104 +43,19 @@ export type InvokeMapStructuredOutputOptions = {
   temperature?: number;
 };
 
-function parseMapStructuredContent(raw: string): MapOutput {
-  const trimmed = extractJsonObjectString(raw) ?? raw.trim();
-  if (!trimmed) {
-    throw new Error("empty LLM content");
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to parse map JSON: ${message}`);
-  }
-
-  const validated = MapOutputSchema.safeParse(parsed);
-  if (!validated.success) {
-    throw new Error(`Map output validation failed: ${validated.error.message}`);
-  }
-
-  return validated.data;
-}
-
-function isRetriableMapStructuredError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const message = error.message.toLowerCase();
-  return (
-    message.includes("empty llm content") ||
-    message.includes("failed to parse map json") ||
-    message.includes("map output validation failed") ||
-    message.includes("no json payload for structured response")
-  );
-}
-
 /**
  * Map-phase structured output via Together `json_schema` (not LangChain tool calling).
- * Up to 3 attempts with exponential backoff; final attempt falls back to `json_object`.
- * Uses `uncachedLlmCall` at temperature 0.3 with reasoning disabled.
+ * @see invokeStructuredOutput for retry / GPT-OSS handling.
  */
 export async function invokeMapStructuredOutput(
   options: InvokeMapStructuredOutputOptions
 ): Promise<MapOutput> {
-  const model = options.model ?? env.FAST_LLM;
-  const maxTokens = options.maxTokens ?? 16_384;
-  const temperature = options.temperature ?? 0.3;
-
-  let lastError: Error | undefined;
-
-  for (let attempt = 0; attempt < MAP_STRUCTURED_MAX_ATTEMPTS; attempt++) {
-    try {
-      const isLastAttempt = attempt === MAP_STRUCTURED_MAX_ATTEMPTS - 1;
-      if (isLastAttempt && attempt > 0) {
-        console.warn(
-          `[ReportMap] Structured output attempt ${attempt + 1}/${MAP_STRUCTURED_MAX_ATTEMPTS} using json_object fallback`
-        );
-      }
-      const userPrompt =
-        attempt === 0
-          ? options.userPrompt
-          : `${options.userPrompt}\n\nREMINDER: Output ONLY a single valid JSON object. No commentary, planning text, or markdown outside the JSON.`;
-
-      const response = await uncachedLlmCall({
-        model,
-        messages: [
-          { role: "system", content: options.systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-        temperature,
-        maxTokens,
-        reasoningEnabled: false,
-        responseFormat: isLastAttempt
-          ? { type: "json_object" }
-          : {
-              type: "json_schema",
-              json_schema: {
-                name: MAP_STRUCTURED_SCHEMA_NAME,
-                schema: MAP_OUTPUT_JSON_SCHEMA,
-              },
-            },
-      });
-
-      const jsonPayload =
-        response.structuredJson?.trim() || extractJsonObjectString(response.content) || "";
-      return parseMapStructuredContent(jsonPayload);
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      if (attempt < MAP_STRUCTURED_MAX_ATTEMPTS - 1 && isRetriableMapStructuredError(error)) {
-        const delayMs = 1000 * 2 ** attempt;
-        console.warn(
-          `[ReportMap] Structured output retry ${attempt + 1}/${MAP_STRUCTURED_MAX_ATTEMPTS}: ${lastError.message}`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        continue;
-      }
-      throw lastError;
-    }
-  }
-
-  throw lastError ?? new Error("Map structured output failed");
+  return invokeStructuredOutput({
+    ...options,
+    schema: MapOutputSchema,
+    schemaName: MAP_STRUCTURED_SCHEMA_NAME,
+    logPrefix: "ReportMap",
+  });
 }
 
 /**

--- a/convex/_agents/written_questions/WrittenQuestionsGraph.ts
+++ b/convex/_agents/written_questions/WrittenQuestionsGraph.ts
@@ -41,7 +41,11 @@ export class WrittenQuestionsGraph {
       modelKwargs: mergeModelKwargs(reduceModel, "smart"),
     });
 
-    this.fastLlmStructured = createStructuredLLM(this.fastLlm, WrittenQuestionsArraySchema);
+    this.fastLlmStructured = createStructuredLLM(WrittenQuestionsArraySchema, {
+      model: mapModel,
+      maxTokens: 16_000,
+      temperature: 0.3,
+    });
   }
 
   buildGraph() {

--- a/convex/_agents/written_questions/nodeReduce.ts
+++ b/convex/_agents/written_questions/nodeReduce.ts
@@ -3,10 +3,9 @@
 import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { Send } from "@langchain/langgraph";
-
+import { env } from "../../_lib/env.js";
 import { invokeWithRetry, invokeWithTimeout, withoutMapOutputs } from "../_shared/index.js";
 import { createAgentGraphLogger } from "../_shared/logging.js";
-
 import { GRAPH_CONFIG } from "./config.js";
 import { callStatusUpdate } from "./nodeSplit.js";
 import { finalizeQuestions, getSelectionPrompt } from "./postprocess.js";
@@ -17,7 +16,6 @@ import {
   type WrittenQuestionsResponse,
 } from "./prompts.js";
 import { detectSimilarQuestions } from "./questionHeuristics.js";
-import { env } from "../../_lib/env.js";
 import type { OverallStateType } from "./state.js";
 import { createStructuredLLM } from "./structuredLlm.js";
 

--- a/convex/_agents/written_questions/nodeReduce.ts
+++ b/convex/_agents/written_questions/nodeReduce.ts
@@ -17,7 +17,9 @@ import {
   type WrittenQuestionsResponse,
 } from "./prompts.js";
 import { detectSimilarQuestions } from "./questionHeuristics.js";
+import { env } from "../../_lib/env.js";
 import type { OverallStateType } from "./state.js";
+import { createStructuredLLM } from "./structuredLlm.js";
 
 export async function reduce(
   state: OverallStateType,
@@ -232,10 +234,12 @@ export async function reduce(
   }
 
   try {
-    const structuredLlm = smartLlm.withStructuredOutput<WrittenQuestionsResponse>(
-      WrittenQuestionsArraySchema,
-      { name: "written_questions_selection" }
-    );
+    const reduceModel = (smartLlm as { model?: string }).model ?? env.WRITTEN_QUESTIONS_LLM;
+    const structuredLlm = createStructuredLLM(WrittenQuestionsArraySchema, {
+      model: reduceModel,
+      schemaName: "written_questions_selection",
+      reasoningEnabled: true,
+    });
 
     const selectionPrompt = getSelectionPrompt({
       questions: questionsForLLM,

--- a/convex/_agents/written_questions/structuredLlm.ts
+++ b/convex/_agents/written_questions/structuredLlm.ts
@@ -1,20 +1,57 @@
 "use node";
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import type { HumanMessage, SystemMessage } from "@langchain/core/messages";
-import { z } from "zod";
-
+import type { z } from "zod";
+import { env } from "../../_lib/env";
+import { invokeStructuredOutput } from "../_shared/structuredLlm.js";
 import type { WrittenQuestionsResponse } from "./prompts.js";
 
 export interface WrittenQuestionsOutputInvoker {
   invoke(messages: Array<SystemMessage | HumanMessage>): Promise<WrittenQuestionsResponse>;
 }
 
-export function createStructuredLLM(
-  llm: ChatTogetherAI,
-  schema: z.ZodTypeAny
-): WrittenQuestionsOutputInvoker {
-  return llm.withStructuredOutput(schema, {
-    name: "written_questions",
-  }) as any;
+function promptsFromMessages(messages: Array<SystemMessage | HumanMessage>): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  const systemPrompt = messages
+    .filter((m) => m.getType() === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  const userPrompt = messages
+    .filter((m) => m.getType() === "human")
+    .map((m) => (typeof m.content === "string" ? m.content : String(m.content)))
+    .join("\n");
+  return { systemPrompt, userPrompt };
+}
+
+export function createStructuredLLM<T = WrittenQuestionsResponse>(
+  schema: z.ZodTypeAny,
+  options?: {
+    model?: string;
+    maxTokens?: number;
+    temperature?: number;
+    schemaName?: string;
+    reasoningEnabled?: boolean;
+  }
+): { invoke(messages: Array<SystemMessage | HumanMessage>): Promise<T> } {
+  const model = options?.model ?? env.FAST_LLM;
+  const schemaName = options?.schemaName ?? "written_questions";
+
+  return {
+    invoke: async (messages) => {
+      const { systemPrompt, userPrompt } = promptsFromMessages(messages);
+      return invokeStructuredOutput({
+        systemPrompt,
+        userPrompt,
+        schema,
+        schemaName,
+        model,
+        maxTokens: options?.maxTokens,
+        temperature: options?.temperature,
+        reasoningEnabled: options?.reasoningEnabled,
+        logPrefix: "WrittenQuestionsStructured",
+      }) as Promise<T>;
+    },
+  };
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -38,6 +38,8 @@ import type * as _agents__shared_sanitization from "../_agents/_shared/sanitizat
 import type * as _agents__shared_stateUpdateHelpers from "../_agents/_shared/stateUpdateHelpers.js";
 import type * as _agents__shared_state_cleanup from "../_agents/_shared/state_cleanup.js";
 import type * as _agents__shared_state_factory from "../_agents/_shared/state_factory.js";
+import type * as _agents__shared_structuredLlm from "../_agents/_shared/structuredLlm.js";
+import type * as _agents__shared_studioTextLlm from "../_agents/_shared/studioTextLlm.js";
 import type * as _agents__shared_timeout from "../_agents/_shared/timeout.js";
 import type * as _agents__shared_tokenizer from "../_agents/_shared/tokenizer.js";
 import type * as _agents__shared_topic_extraction from "../_agents/_shared/topic_extraction.js";
@@ -285,6 +287,7 @@ import type * as notebooks__forkNotebook from "../notebooks/_forkNotebook.js";
 import type * as notebooks_index from "../notebooks/index.js";
 import type * as notebooks_sharing from "../notebooks/sharing.js";
 import type * as notes_index from "../notes/index.js";
+import type * as notes_listSummary from "../notes/listSummary.js";
 import type * as notes_userNotes from "../notes/userNotes.js";
 import type * as onboarding_constants from "../onboarding/constants.js";
 import type * as onboarding_mutations from "../onboarding/mutations.js";
@@ -389,6 +392,8 @@ declare const fullApi: ApiFromModules<{
   "_agents/_shared/stateUpdateHelpers": typeof _agents__shared_stateUpdateHelpers;
   "_agents/_shared/state_cleanup": typeof _agents__shared_state_cleanup;
   "_agents/_shared/state_factory": typeof _agents__shared_state_factory;
+  "_agents/_shared/structuredLlm": typeof _agents__shared_structuredLlm;
+  "_agents/_shared/studioTextLlm": typeof _agents__shared_studioTextLlm;
   "_agents/_shared/timeout": typeof _agents__shared_timeout;
   "_agents/_shared/tokenizer": typeof _agents__shared_tokenizer;
   "_agents/_shared/topic_extraction": typeof _agents__shared_topic_extraction;
@@ -636,6 +641,7 @@ declare const fullApi: ApiFromModules<{
   "notebooks/index": typeof notebooks_index;
   "notebooks/sharing": typeof notebooks_sharing;
   "notes/index": typeof notes_index;
+  "notes/listSummary": typeof notes_listSummary;
   "notes/userNotes": typeof notes_userNotes;
   "onboarding/constants": typeof onboarding_constants;
   "onboarding/mutations": typeof onboarding_mutations;

--- a/convex/notes/index.ts
+++ b/convex/notes/index.ts
@@ -3,6 +3,7 @@ import { query } from "../_generated/server";
 import { assertCanReadNotebook } from "../_lib/notebookAccess";
 import * as NotesModel from "../_model/notes";
 import { getAuthUserId } from "../auth";
+import { summarizeListRow } from "./listSummary";
 
 /**
  * Unified query to fetch all note types for a notebook in a single request.
@@ -138,7 +139,11 @@ export const list = query({
     }
 
     const results = await Promise.all(queries);
-    const allNotes = results.flat();
+    const allNotes = results
+      .flat()
+      .map((item) => summarizeListRow(item as Record<string, unknown> & { _type: string })) as Array<
+      Record<string, unknown> & { updatedAt: number }
+    >;
 
     allNotes.sort((a, b) => b.updatedAt - a.updatedAt);
 

--- a/convex/notes/index.ts
+++ b/convex/notes/index.ts
@@ -141,9 +141,9 @@ export const list = query({
     const results = await Promise.all(queries);
     const allNotes = results
       .flat()
-      .map((item) => summarizeListRow(item as Record<string, unknown> & { _type: string })) as Array<
-      Record<string, unknown> & { updatedAt: number }
-    >;
+      .map((item) =>
+        summarizeListRow(item as Record<string, unknown> & { _type: string })
+      ) as Array<Record<string, unknown> & { updatedAt: number }>;
 
     allNotes.sort((a, b) => b.updatedAt - a.updatedAt);
 

--- a/convex/notes/listSummary.test.ts
+++ b/convex/notes/listSummary.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  summarizeFlashcardRow,
-  summarizeReportRow,
-  summarizeUserNoteRow,
-} from "./listSummary";
+import { summarizeFlashcardRow, summarizeReportRow, summarizeUserNoteRow } from "./listSummary";
 
 describe("listSummary", () => {
   it("strips report content but keeps metadata", () => {

--- a/convex/notes/listSummary.test.ts
+++ b/convex/notes/listSummary.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  summarizeFlashcardRow,
+  summarizeReportRow,
+  summarizeUserNoteRow,
+} from "./listSummary";
+
+describe("listSummary", () => {
+  it("strips report content but keeps metadata", () => {
+    const row = summarizeReportRow({
+      _id: "r1",
+      title: "Report",
+      content: "x".repeat(10_000),
+      status: "completed",
+      metadata: { reportType: "summary" },
+    });
+    expect(row).not.toHaveProperty("content");
+    expect(row).toMatchObject({ title: "Report", status: "completed" });
+  });
+
+  it("replaces flashcard cardsData with count", () => {
+    const row = summarizeFlashcardRow({
+      _id: "f1",
+      title: "Cards",
+      cardsData: [{ q: "1" }, { q: "2" }],
+      status: "completed",
+    });
+    expect(row).not.toHaveProperty("cardsData");
+    expect(row).toMatchObject({ _cardsCount: 2 });
+  });
+
+  it("truncates user note content for list previews", () => {
+    const row = summarizeUserNoteRow({
+      _id: "n1",
+      title: "Note",
+      content: "a".repeat(500),
+      messages: [{ role: "user", content: "hi" }],
+      status: "completed",
+    });
+    expect(row).not.toHaveProperty("messages");
+    expect((row as { content: string }).content).toHaveLength(200);
+    expect(row).toMatchObject({ _contentTruncated: true });
+  });
+});

--- a/convex/notes/listSummary.ts
+++ b/convex/notes/listSummary.ts
@@ -1,0 +1,91 @@
+/**
+ * Strip heavy payloads from studio list rows. Full content loads via `notes.index.get`.
+ */
+
+const LIST_CONTENT_PREVIEW_CHARS = 200;
+
+function countArray(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export function summarizeReportRow<T extends { content?: unknown }>(item: T) {
+  const { content: _content, ...rest } = item;
+  return rest;
+}
+
+export function summarizeFlashcardRow<T extends { cardsData?: unknown }>(item: T) {
+  const { cardsData, ...rest } = item;
+  return { ...rest, _cardsCount: countArray(cardsData) };
+}
+
+export function summarizeQuizRow<T extends { questionsData?: unknown }>(item: T) {
+  const { questionsData, ...rest } = item;
+  return { ...rest, _questionsCount: countArray(questionsData) };
+}
+
+export function summarizeMindMapRow<T extends { data?: unknown }>(item: T) {
+  const { data: _data, ...rest } = item;
+  return rest;
+}
+
+export function summarizeAudioOverviewRow<T extends { transcript?: unknown }>(item: T) {
+  const { transcript: _transcript, ...rest } = item;
+  return rest;
+}
+
+export function summarizeInfographicRow<T extends { data?: { imageUrl?: string } | unknown }>(
+  item: T
+) {
+  const data = item.data;
+  const imageUrl =
+    data && typeof data === "object" && data !== null && "imageUrl" in data
+      ? (data as { imageUrl?: string }).imageUrl
+      : undefined;
+  const { data: _data, ...rest } = item;
+  return imageUrl ? { ...rest, _imageUrl: imageUrl } : rest;
+}
+
+export function summarizeSpreadsheetRow<T extends { data?: unknown }>(item: T) {
+  const { data: _data, ...rest } = item;
+  return rest;
+}
+
+export function summarizeWrittenQuestionsRow<T extends { questionsData?: unknown }>(item: T) {
+  const { questionsData, ...rest } = item;
+  return { ...rest, _questionsCount: countArray(questionsData) };
+}
+
+export function summarizeUserNoteRow<T extends { content?: unknown; messages?: unknown }>(item: T) {
+  const { messages: _messages, content, ...rest } = item;
+  const text = typeof content === "string" ? content : "";
+  return {
+    ...rest,
+    content: text.slice(0, LIST_CONTENT_PREVIEW_CHARS),
+    _contentTruncated: text.length > LIST_CONTENT_PREVIEW_CHARS,
+  };
+}
+
+export function summarizeListRow(item: Record<string, unknown> & { _type: string }) {
+  switch (item._type) {
+    case "report":
+      return summarizeReportRow(item as { content?: unknown });
+    case "flashcard":
+      return summarizeFlashcardRow(item as { cardsData?: unknown });
+    case "quiz":
+      return summarizeQuizRow(item as { questionsData?: unknown });
+    case "mindmap":
+      return summarizeMindMapRow(item as { data?: unknown });
+    case "audioOverview":
+      return summarizeAudioOverviewRow(item as { transcript?: unknown });
+    case "infographic":
+      return summarizeInfographicRow(item as { data?: { imageUrl?: string } | unknown });
+    case "spreadsheet":
+      return summarizeSpreadsheetRow(item as { data?: unknown });
+    case "writtenQuestions":
+      return summarizeWrittenQuestionsRow(item as { questionsData?: unknown });
+    case "note":
+      return summarizeUserNoteRow(item as { content?: unknown; messages?: unknown });
+    default:
+      return item;
+  }
+}

--- a/convex/studio/audio/audioJobPhases.ts
+++ b/convex/studio/audio/audioJobPhases.ts
@@ -14,8 +14,8 @@ import {
   validateChunks,
 } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { invokeTogetherText } from "../../_agents/_shared/studioTextLlm";
 import {
   type AudioLength,
   type AudioType,
@@ -83,28 +83,6 @@ const VOICES = {
 // ============================================================
 // HELPER: Create LLMs
 // ============================================================
-
-function createMapLLM(): ChatTogetherAI {
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model: env.FAST_LLM,
-    temperature: 0.3,
-    timeout: CONFIG.PER_CHUNK_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(env.FAST_LLM, "fast"),
-  });
-}
-
-function createReduceLLM(): ChatTogetherAI {
-  const model = env.AUDIO_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.6,
-    maxTokens: CONFIG.REDUCE_MAX_OUTPUT_TOKENS,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
 
 // ============================================================
 // PHASE 1: Initialize & Schedule Map Tasks
@@ -284,7 +262,6 @@ export async function runProcessAudioMapChunkPhase(
     const language = userPrefs?.outputLanguage;
 
     // Process with LLM - extract dialogue beats
-    const llm = createMapLLM();
     const metadata = (audioOverview.metadata ?? {}) as {
       audioType?: AudioType;
       focus?: string;
@@ -299,12 +276,14 @@ export async function runProcessAudioMapChunkPhase(
     console.log(`[AudioJob] ${chunkId} Calling LLM (${prompt.length} chars)`);
 
     const startTime = Date.now();
-    const response = await invokeStudioLlm({
+    const output = await invokeStudioLlm({
       invoke: () =>
-        (llm as any).invoke([
-          new SystemMessage(withLanguageInstruction(MAP_SYSTEM_PROMPT, language)),
-          new HumanMessage(prompt),
-        ]),
+        invokeTogetherText({
+          systemPrompt: withLanguageInstruction(MAP_SYSTEM_PROMPT, language),
+          userPrompt: prompt,
+          model: env.FAST_LLM,
+          temperature: 0.3,
+        }),
       timeoutMs: CONFIG.PER_CHUNK_TIMEOUT_MS,
       phaseLabel: "AudioMap",
       onRetry: (attempt, error) => {
@@ -313,7 +292,6 @@ export async function runProcessAudioMapChunkPhase(
     });
 
     const elapsed = Date.now() - startTime;
-    const output = String((response as any).content);
 
     console.log(`[AudioJob] ${chunkId} LLM completed in ${elapsed}ms`);
 
@@ -541,7 +519,6 @@ export async function runFinalizeAudioOverviewPhase(
     const sanitizedFocus = storedMetadata.focus
       ? sanitizeUserInput(storedMetadata.focus)
       : undefined;
-    const llm = createReduceLLM();
     const targetLines = TARGET_LINE_COUNTS[length];
 
     let fullDialogueScript: DialogueLine[] = [];
@@ -562,41 +539,26 @@ export async function runFinalizeAudioOverviewPhase(
       `[AudioJob] Writing script single-pass (promptChars=${reducePrompt.length}, promptTokens=${countTokens(reducePrompt)}, targetLines=${targetLines})`
     );
 
-    const response = await invokeStudioLlm({
+    const responseText = await invokeStudioLlm({
       invoke: () =>
-        (llm as any).invoke([
-          new SystemMessage(withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language)),
-          new HumanMessage(reducePrompt),
-        ]),
+        invokeTogetherText({
+          systemPrompt: withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language),
+          userPrompt: reducePrompt,
+          model: env.AUDIO_LLM,
+          maxTokens: CONFIG.REDUCE_MAX_OUTPUT_TOKENS,
+          temperature: 0.6,
+          reasoningEnabled: true,
+        }),
       timeoutMs: CONFIG.REDUCE_TIMEOUT_MS,
       phaseLabel: "AudioReduce",
       retry: { maxAttempts: 2, baseDelayMs: 1000 },
     });
 
-    const responseAny = response as any;
-    const responseContent = responseAny?.content;
-    const responseText =
-      typeof responseContent === "string"
-        ? responseContent
-        : Array.isArray(responseContent)
-          ? responseContent
-              .map((part: any) => {
-                if (typeof part === "string") return part;
-                if (part && typeof part === "object" && typeof part.text === "string")
-                  return part.text;
-                return "";
-              })
-              .join("")
-          : String(responseContent ?? "");
-    const finishReason =
-      responseAny?.response_metadata?.finish_reason ??
-      responseAny?.response_metadata?.finishReason ??
-      null;
     const jsonStart = responseText.indexOf("[");
     const jsonEnd = responseText.lastIndexOf("]");
 
     console.log(
-      `[AudioJob] Script response responseChars=${responseText.length}, jsonStart=${jsonStart}, jsonEnd=${jsonEnd}, finishReason=${finishReason ?? "unknown"}`
+      `[AudioJob] Script response responseChars=${responseText.length}, jsonStart=${jsonStart}, jsonEnd=${jsonEnd}`
     );
 
     // Try multiple parsing strategies

--- a/convex/studio/flashcards/flashcardJobPhases.ts
+++ b/convex/studio/flashcards/flashcardJobPhases.ts
@@ -317,8 +317,10 @@ export async function runProcessFlashcardMapChunkPhase(
     const language = userPrefs?.outputLanguage;
 
     // Process with LLM using structured output
-    const llm = createMapLLM();
-    const structuredLLM = createStructuredLLM(llm, FlashcardArraySchema);
+    const structuredLLM = createStructuredLLM(FlashcardArraySchema, {
+      model: env.FAST_LLM,
+      temperature: 0.3,
+    });
 
     const sanitizedTopic = topic ? sanitizeUserInput(topic) : undefined;
     const prompt = getMapPrompt({

--- a/convex/studio/infographic/generate.ts
+++ b/convex/studio/infographic/generate.ts
@@ -2,6 +2,10 @@
 
 import { v } from "convex/values";
 import { invokeWithRetry } from "../../_agents/_shared/index";
+import {
+  extractJsonObjectString,
+  uncachedLlmCall,
+} from "../../_agents/_shared/cachedLlm";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
 import { internal } from "../../_generated/api";
 import { internalAction } from "../../_generated/server";
@@ -191,7 +195,7 @@ export const generateInfographicImage = internalAction({
       logger.phaseStart("content_analysis");
       const designResponse = await invokeWithRetry(
         () =>
-          togetherClient.chat.completions.create({
+          uncachedLlmCall({
             model: env.SMART_LLM,
             messages: [
               {
@@ -241,6 +245,8 @@ Return JSON: {
               },
             ],
             temperature: 0.7,
+            reasoningEnabled: true,
+            responseFormat: { type: "json_object" },
           }),
         {
           maxAttempts: 3,
@@ -255,7 +261,11 @@ Return JSON: {
         "InfographicDesignGen"
       );
 
-      const designContent = designResponse.choices[0]?.message?.content || "{}";
+      const designContent =
+        designResponse.structuredJson?.trim() ||
+        extractJsonObjectString(designResponse.content) ||
+        designResponse.content ||
+        "{}";
       const design = parseLlmJson(designContent) as Record<string, any>;
       if (!design.image_prompt) {
         throw new Error(

--- a/convex/studio/infographic/generate.ts
+++ b/convex/studio/infographic/generate.ts
@@ -1,11 +1,8 @@
 "use node";
 
 import { v } from "convex/values";
+import { extractJsonObjectString, uncachedLlmCall } from "../../_agents/_shared/cachedLlm";
 import { invokeWithRetry } from "../../_agents/_shared/index";
-import {
-  extractJsonObjectString,
-  uncachedLlmCall,
-} from "../../_agents/_shared/cachedLlm";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
 import { internal } from "../../_generated/api";
 import { internalAction } from "../../_generated/server";

--- a/convex/studio/jobMutations/spreadsheets.ts
+++ b/convex/studio/jobMutations/spreadsheets.ts
@@ -9,16 +9,21 @@ export const saveSpreadsheetResults = internalMutation({
     metadata: v.any(),
   },
   handler: async (ctx, args) => {
+    const spreadsheet = await ctx.db.get(args.spreadsheetId);
+    if (!spreadsheet) return null;
+
     await ctx.db.patch(args.spreadsheetId, {
       data: args.spreadsheet,
       status: "completed",
       updatedAt: Date.now(),
       title: args.metadata?.title ?? "Spreadsheet",
       metadata: {
+        ...spreadsheet.metadata,
         ...args.metadata,
         completedAt: Date.now(),
       },
     });
+    return args.spreadsheetId;
   },
 });
 
@@ -42,14 +47,21 @@ export const updateSpreadsheetStatus = internalMutation({
     metadata: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
-    const updates: any = {
+    const spreadsheet = await ctx.db.get(args.spreadsheetId);
+    if (!spreadsheet) return null;
+
+    const updates: Record<string, unknown> = {
       status: args.status,
       updatedAt: Date.now(),
     };
     if (args.metadata) {
-      updates.metadata = args.metadata;
+      updates.metadata = {
+        ...spreadsheet.metadata,
+        ...args.metadata,
+      };
     }
     await ctx.db.patch(args.spreadsheetId, updates);
+    return args.spreadsheetId;
   },
 });
 
@@ -60,6 +72,9 @@ export const markSpreadsheetFailed = internalMutation({
     metadata: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
+    const spreadsheet = await ctx.db.get(args.spreadsheetId);
+    if (!spreadsheet) return null;
+
     const errorMetadata = buildErrorMetadata(
       args.error,
       args.metadata?.phase || "unknown",
@@ -69,10 +84,12 @@ export const markSpreadsheetFailed = internalMutation({
       status: "failed",
       updatedAt: Date.now(),
       metadata: {
+        ...spreadsheet.metadata,
         ...args.metadata,
         ...errorMetadata,
       },
     });
+    return args.spreadsheetId;
   },
 });
 

--- a/convex/studio/literature_tables/index.test.ts
+++ b/convex/studio/literature_tables/index.test.ts
@@ -150,7 +150,6 @@ describe("saveLiteratureReportAsStudioReport", () => {
           _type: "report",
           title: "Literature Report",
           status: "completed",
-          content: "# Literature Report\n\nFindings with citations.",
           metadata: expect.objectContaining({
             reportType: "literature_review",
             sourceLiteratureReportId: literatureReportId,
@@ -159,6 +158,13 @@ describe("saveLiteratureReportAsStudioReport", () => {
         }),
       ])
     );
+    expect(savedReports[0]).not.toHaveProperty("content");
+
+    const fullReport = await withAuth(t, userId).query(api.notes.index.get, {
+      type: "report",
+      id: reportId,
+    });
+    expect(fullReport?.content).toBe("# Literature Report\n\nFindings with citations.");
   });
 });
 
@@ -244,7 +250,6 @@ describe("saveLiteratureTableAsStudioSpreadsheet", () => {
           _type: "spreadsheet",
           title: "Saved Literature Table",
           status: "completed",
-          data: expect.stringContaining("Updated result"),
           metadata: expect.objectContaining({
             spreadsheetType: "literature_review",
             sourceLiteratureTableId: literatureTableId,
@@ -252,5 +257,12 @@ describe("saveLiteratureTableAsStudioSpreadsheet", () => {
         }),
       ])
     );
+    expect(savedNotes[0]).not.toHaveProperty("data");
+
+    const fullSpreadsheet = await withAuth(t, userId).query(api.notes.index.get, {
+      type: "spreadsheet",
+      id: spreadsheetId,
+    });
+    expect(fullSpreadsheet?.data).toEqual(expect.stringContaining("Updated result"));
   });
 });

--- a/convex/studio/mindmaps/mindmapJobPhases.ts
+++ b/convex/studio/mindmaps/mindmapJobPhases.ts
@@ -5,13 +5,13 @@
  * @see ./job.ts for Convex `internalAction` registrations.
  */
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
-import { BaseMessage, HumanMessage, SystemMessage } from "@langchain/core/messages";
-import { z } from "zod";
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { validateWithPreset } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { invokeStructuredOutput } from "../../_agents/_shared/structuredLlm";
+import { invokeTogetherText } from "../../_agents/_shared/studioTextLlm";
+import { ConceptExtractionSchema } from "../../_agents/mindmap/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/MindMapGraph";
 import {
   MAP_PROMPT,
@@ -25,28 +25,6 @@ import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { env } from "../../_lib/env";
 import { invokeStudioLlm } from "../_job/invokeStudioLlm";
-
-// ============================================================
-// SCHEMAS
-// ============================================================
-
-const ConceptExtractionSchema = z.object({
-  main_theme: z.string(),
-  summary: z.string(),
-  key_concepts: z.array(z.string()),
-});
-
-// Interface for the structured LLM to avoid deep type instantiation
-interface ConceptExtractionInvoker {
-  invoke(messages: Array<SystemMessage | HumanMessage>, config?: any): Promise<ConceptExtraction>;
-}
-
-// Helper function to create a structured LLM without triggering deep type instantiation
-function createConceptExtractionLLM(llm: ChatTogetherAI): ConceptExtractionInvoker {
-  return llm.withStructuredOutput(ConceptExtractionSchema, {
-    name: "concept_extraction",
-  });
-}
 
 // ============================================================
 // CONFIGURATION
@@ -79,33 +57,6 @@ export type FinalizeMindMapPhaseArgs = {
   userId: string;
   notebookId: Id<"notebooks">;
 };
-
-// ============================================================
-// HELPER: Create structured LLM for map phase
-// ============================================================
-
-function createMapLLM(): ChatTogetherAI {
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model: env.FAST_LLM,
-    temperature: 0.1,
-    timeout: CONFIG.PER_CHUNK_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(env.FAST_LLM, "fast"),
-    maxTokens: 8000,
-  });
-}
-
-function createReduceLLM(): ChatTogetherAI {
-  const model = env.MINDMAP_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.3,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    maxTokens: 16000,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
 
 // ============================================================
 // MARKDOWN PARSER
@@ -377,21 +328,23 @@ export async function runProcessMindMapMapChunkPhase(
     }
     const language = userPrefs?.outputLanguage;
 
-    // Process with LLM using structured output
-    const llm = createMapLLM();
-    const structuredLLM = createConceptExtractionLLM(llm);
-
     const prompt = MAP_PROMPT.replace("{content}", chunk);
 
     console.log(`[MindMapJob] ${chunkId} Calling LLM (${prompt.length} chars)`);
 
     const startTime = Date.now();
-    const response = await invokeStudioLlm({
+    const extraction = await invokeStudioLlm({
       invoke: () =>
-        (structuredLLM as any).invoke([
-          new SystemMessage(withLanguageInstruction(MAP_SYSTEM_PROMPT, language)),
-          new HumanMessage(prompt),
-        ]),
+        invokeStructuredOutput({
+          systemPrompt: withLanguageInstruction(MAP_SYSTEM_PROMPT, language),
+          userPrompt: prompt,
+          schema: ConceptExtractionSchema,
+          schemaName: "concept_extraction",
+          model: env.FAST_LLM,
+          temperature: 0.1,
+          maxTokens: 8000,
+          logPrefix: "MindMapMap",
+        }),
       timeoutMs: CONFIG.PER_CHUNK_TIMEOUT_MS,
       phaseLabel: "MindMapMap",
       onRetry: (attempt, error) => {
@@ -403,7 +356,6 @@ export async function runProcessMindMapMapChunkPhase(
     console.log(`[MindMapJob] ${chunkId} LLM completed in ${elapsed}ms`);
 
     // Store result
-    const extraction = response as ConceptExtraction;
     const result = {
       extraction,
       processingTimeMs: elapsed,
@@ -594,9 +546,6 @@ export async function runFinalizeMindMapPhase(
       },
     });
 
-    // Build the mind map using reduce phase
-    const llm = createReduceLLM();
-
     const inputData = allExtractions
       .map(
         (e) =>
@@ -614,19 +563,19 @@ export async function runFinalizeMindMapPhase(
 
     try {
       const startTime = Date.now();
-      const response = await invokeStudioLlm({
+      const markdown = await invokeStudioLlm({
         invoke: () =>
-          (llm as any).invoke([
-            new SystemMessage(withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language)),
-            new HumanMessage(REDUCE_PROMPT.replace("{extractions}", safeInput)),
-          ]),
+          invokeTogetherText({
+            systemPrompt: withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language),
+            userPrompt: REDUCE_PROMPT.replace("{extractions}", safeInput),
+            model: env.MINDMAP_LLM,
+            maxTokens: 16_000,
+            temperature: 0.3,
+            reasoningEnabled: true,
+          }),
         timeoutMs: CONFIG.REDUCE_TIMEOUT_MS,
         phaseLabel: "MindMapReduce",
       });
-
-      const markdown =
-        ((response as BaseMessage).content[0] as { text?: string })?.text ||
-        String((response as BaseMessage).content);
 
       const validation = validateWithPreset(markdown, "mindmap");
       if (!validation.isValid) {

--- a/convex/studio/mindmaps/mindmapJobPhases.ts
+++ b/convex/studio/mindmaps/mindmapJobPhases.ts
@@ -11,7 +11,6 @@ import { withLanguageInstruction } from "../../_agents/_shared/languageInstructi
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
 import { invokeStructuredOutput } from "../../_agents/_shared/structuredLlm";
 import { invokeTogetherText } from "../../_agents/_shared/studioTextLlm";
-import { ConceptExtractionSchema } from "../../_agents/mindmap/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/MindMapGraph";
 import {
   MAP_PROMPT,
@@ -20,6 +19,7 @@ import {
   REDUCE_SYSTEM_PROMPT,
 } from "../../_agents/mindmap/prompts";
 import type { ConceptExtraction, FinalMindMap, MindMapNode } from "../../_agents/mindmap/state";
+import { ConceptExtractionSchema } from "../../_agents/mindmap/structuredLlm";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";

--- a/convex/studio/quizzes/quizJobPhases.ts
+++ b/convex/studio/quizzes/quizJobPhases.ts
@@ -9,7 +9,6 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { allWithConcurrency, sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
-import { createStructuredLLM } from "../../_agents/quiz/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/QuizGraph";
 import {
   applySelectedCandidateIndices,
@@ -29,6 +28,7 @@ import {
   QuizQuestionSchema,
   REDUCE_SELECT_SYSTEM_PROMPT,
 } from "../../_agents/quiz/prompts";
+import { createStructuredLLM } from "../../_agents/quiz/structuredLlm";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";

--- a/convex/studio/quizzes/quizJobPhases.ts
+++ b/convex/studio/quizzes/quizJobPhases.ts
@@ -5,12 +5,11 @@
  * @see ./job.ts for Convex `internalAction` registrations.
  */
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { allWithConcurrency, sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { createStructuredLLM } from "../../_agents/quiz/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/QuizGraph";
 import {
   applySelectedCandidateIndices,
@@ -35,31 +34,6 @@ import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { env } from "../../_lib/env";
 import { invokeStudioLlm } from "../_job/invokeStudioLlm";
-
-// Interface for the structured LLM to avoid deep type instantiation
-interface QuizCandidateOutputInvoker {
-  invoke(
-    messages: Array<SystemMessage | HumanMessage>,
-    config?: any
-  ): Promise<QuizCandidateResponse>;
-}
-
-interface QuizQuestionOutputInvoker {
-  invoke(messages: Array<SystemMessage | HumanMessage>, config?: any): Promise<QuizQuestion>;
-}
-
-// Helper function to create a structured LLM without triggering deep type instantiation
-function createCandidateLLM(llm: ChatTogetherAI): QuizCandidateOutputInvoker {
-  return llm.withStructuredOutput(QuizCandidateArraySchema, {
-    name: "quiz_candidates",
-  });
-}
-
-function createQuestionLLM(llm: ChatTogetherAI): QuizQuestionOutputInvoker {
-  return llm.withStructuredOutput(QuizQuestionSchema, {
-    name: "quiz_question",
-  });
-}
 
 // ============================================================
 // CONFIGURATION
@@ -130,48 +104,6 @@ export type FinalizeQuizPhaseArgs = {
   difficulty: string;
   focus?: string;
 };
-
-// ============================================================
-// HELPER: Create structured LLM for map phase
-// ============================================================
-
-function createMapLLM(): ChatTogetherAI {
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model: env.FAST_LLM,
-    temperature: 0.4,
-    timeout: CONFIG.PER_CHUNK_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(env.FAST_LLM, "fast"),
-    // Increased from 8000 to handle large chunks (19-22K chars = ~6-8K input tokens)
-    // Need room for 8 candidates × ~300 tokens each = ~2400 output tokens
-    // Total: ~6K input + ~2.4K output + ~1K prompt = ~10K tokens minimum
-    maxTokens: 16_000,
-  });
-}
-
-function createReduceLLM(): ChatTogetherAI {
-  const model = env.QUIZ_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.3,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    maxTokens: 24_000,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
-
-function createExpandLLM(): ChatTogetherAI {
-  const model = env.QUIZ_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.3,
-    timeout: CONFIG.EXPAND_TIMEOUT_MS,
-    maxTokens: 4_096,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
 
 // ============================================================
 // PHASE 1: Initialize & Schedule Map Tasks
@@ -371,9 +303,11 @@ export async function runProcessQuizMapChunkPhase(
     }
     const language = userPrefs?.outputLanguage;
 
-    // Process with LLM using structured output
-    const llm = createMapLLM();
-    const structuredLLM = createCandidateLLM(llm);
+    const structuredLLM = createStructuredLLM<QuizCandidateResponse>(
+      QuizCandidateArraySchema,
+      "quiz_candidates",
+      { model: env.FAST_LLM, temperature: 0.4, maxTokens: 16_000 }
+    );
 
     const sanitizedFocus = focus ? sanitizeUserInput(focus) : undefined;
 
@@ -667,10 +601,16 @@ export async function runFinalizeQuizPhase(
     });
 
     // Selection phase: LLM returns 1-based candidate IDs (not full-object echo — reduces position bias)
-    const selectLLM = createReduceLLM();
-    const structuredSelectLLM = selectLLM.withStructuredOutput(QuizCandidateIndexSelectionSchema, {
-      name: "quiz_candidate_index_selection",
-    });
+    const structuredSelectLLM = createStructuredLLM<QuizCandidateIndexSelection>(
+      QuizCandidateIndexSelectionSchema,
+      "quiz_candidate_index_selection",
+      {
+        model: env.QUIZ_LLM,
+        maxTokens: 24_000,
+        temperature: 0.3,
+        reasoningEnabled: true,
+      }
+    );
 
     const sanitizedFocus = focus ? sanitizeUserInput(focus) : undefined;
     const selectionPrompt = getCandidateSelectionPrompt({
@@ -742,8 +682,16 @@ export async function runFinalizeQuizPhase(
     });
 
     // Expand candidates into full questions with distractors
-    const expandLLM = createExpandLLM();
-    const structuredExpandLLM = createQuestionLLM(expandLLM);
+    const structuredExpandLLM = createStructuredLLM<QuizQuestion>(
+      QuizQuestionSchema,
+      "quiz_question",
+      {
+        model: env.QUIZ_LLM,
+        maxTokens: 4_096,
+        temperature: 0.3,
+        reasoningEnabled: true,
+      }
+    );
 
     console.log(
       `[QuizJob] Expanding ${selectedCandidates.length} candidates with concurrency ${CONFIG.EXPAND_CONCURRENCY}`

--- a/convex/studio/reports/reportJobPhases.ts
+++ b/convex/studio/reports/reportJobPhases.ts
@@ -4,12 +4,10 @@
  * Report generation phase implementations (invoked from thin `job.ts` registrations).
  */
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
-import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { invokeTogetherText } from "../../_agents/_shared/studioTextLlm";
 import { packChunks, validateChunks } from "../../_agents/ReportGraph";
 import {
   MAP_PROMPTS,
@@ -33,19 +31,6 @@ const CONFIG = {
   MAX_OUTPUT_TOKENS: 32_000,
   MIN_SUMMARY_LENGTH: 50,
 } as const;
-
-function createReduceLLM(modelOverride?: string): ChatTogetherAI {
-  const model = modelOverride || env.REPORT_LLM;
-  console.log(`[ReportJob] Reduce model: ${model}`);
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.5,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    maxTokens: CONFIG.MAX_OUTPUT_TOKENS,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
 
 export type ReportGenerationPhaseArgs = {
   reportId: Id<"reports">;
@@ -464,7 +449,7 @@ export async function runFinalizeReportPhase(
       },
     });
 
-    const llm = createReduceLLM(smartLlm);
+    const reduceModel = smartLlm || env.REPORT_LLM;
     const promptTemplate = REDUCE_PROMPTS[reportType] || REDUCE_PROMPTS["custom"];
 
     let prompt = promptTemplate
@@ -481,22 +466,24 @@ export async function runFinalizeReportPhase(
     console.log(`[ReportJob] Reduce prompt: ${prompt.length} chars`);
 
     const startTime = Date.now();
-    const response = (await invokeStudioLlm({
+    let content = await invokeStudioLlm({
       invoke: () =>
-        (llm as any).invoke([
-          new SystemMessage(withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language)),
-          new HumanMessage(prompt),
-        ]),
+        invokeTogetherText({
+          systemPrompt: withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language),
+          userPrompt: prompt,
+          model: reduceModel,
+          maxTokens: CONFIG.MAX_OUTPUT_TOKENS,
+          temperature: 0.5,
+          reasoningEnabled: true,
+        }),
       timeoutMs: CONFIG.REDUCE_TIMEOUT_MS,
       phaseLabel: "ReportReduce",
       onRetry: (attempt, error) => {
         console.log(`[ReportJob] Reduce retry ${attempt}/3: ${error.message}`);
       },
-    })) as { content: unknown };
+    });
 
     const elapsed = Date.now() - startTime;
-    let content =
-      typeof response.content === "string" ? response.content : String(response.content);
 
     if (failedCount.count > 0) {
       const omitted = failedCount.count === 1 ? "section" : "sections";

--- a/convex/studio/spreadsheets/spreadsheetJobPhases.ts
+++ b/convex/studio/spreadsheets/spreadsheetJobPhases.ts
@@ -5,12 +5,11 @@
  * @see ./job.ts for Convex `internalAction` registrations.
  */
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { allWithConcurrency, sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { invokeTogetherText } from "../../_agents/_shared/studioTextLlm";
 import { packChunks, validateChunks } from "../../_agents/SpreadsheetGraph";
 import {
   COLLAPSE_PROMPTS,
@@ -65,52 +64,6 @@ export type FinalizeSpreadsheetPhaseArgs = {
   spreadsheetType: string;
   customPrompt: string;
 };
-
-// ============================================================
-// HELPER: Create LLMs
-// ============================================================
-
-function createMapLLM(): ChatTogetherAI {
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model: env.FAST_LLM,
-    temperature: 0.3,
-    timeout: CONFIG.PER_CHUNK_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(env.FAST_LLM, "fast"),
-    maxTokens: 8_192,
-  });
-}
-
-function createReduceLLM(): ChatTogetherAI {
-  const model = env.SPREADSHEET_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.5,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    maxTokens: 32_000,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
-
-// ============================================================
-// HELPER: Extract message content
-// ============================================================
-
-function getMessageContent(response: unknown): string {
-  if (typeof response === "object" && response !== null) {
-    const msg = response as { content?: unknown };
-    if (typeof msg.content === "string") {
-      return msg.content;
-    }
-    if (typeof msg.content === "object" && msg.content !== null) {
-      if (typeof (msg.content as { toString?: () => string }).toString === "function") {
-        return (msg.content as { toString: () => string }).toString();
-      }
-    }
-  }
-  return String(response);
-}
 
 // ============================================================
 // HELPER: Clean CSV output
@@ -374,9 +327,6 @@ export async function runProcessSpreadsheetMapChunkPhase(
     }
     const language = userPrefs?.outputLanguage;
 
-    // Process with LLM (plain text output)
-    const llm = createMapLLM();
-
     // If customPrompt is provided, use the custom template
     // Otherwise, use the predefined template for the spreadsheet type
     const promptTemplate =
@@ -390,12 +340,15 @@ export async function runProcessSpreadsheetMapChunkPhase(
     console.log(`[SpreadsheetJob] ${chunkId} Calling LLM (${prompt.length} chars)`);
 
     const startTime = Date.now();
-    const response = await invokeStudioLlm({
+    const mapOutput = await invokeStudioLlm({
       invoke: () =>
-        (llm as any).invoke([
-          new SystemMessage(withLanguageInstruction(MAP_SYSTEM_PROMPT, language)),
-          new HumanMessage(prompt),
-        ]),
+        invokeTogetherText({
+          systemPrompt: withLanguageInstruction(MAP_SYSTEM_PROMPT, language),
+          userPrompt: prompt,
+          model: env.FAST_LLM,
+          maxTokens: 8_192,
+          temperature: 0.3,
+        }),
       timeoutMs: CONFIG.PER_CHUNK_TIMEOUT_MS,
       phaseLabel: "SpreadsheetMap",
       onRetry: (attempt, error) => {
@@ -404,7 +357,6 @@ export async function runProcessSpreadsheetMapChunkPhase(
     });
 
     const elapsed = Date.now() - startTime;
-    const mapOutput = getMessageContent(response);
 
     console.log(
       `[SpreadsheetJob] ${chunkId} LLM completed in ${elapsed}ms, output: ${mapOutput.length} chars`
@@ -641,7 +593,6 @@ export async function runFinalizeSpreadsheetPhase(
     });
 
     // Stage 2: Reduce (Generate CSV)
-    const reduceLLM = createReduceLLM();
     const combined = collapsedOutputs.join("\n\n---\n\n");
 
     // Get the reduce prompt based on spreadsheet type
@@ -657,25 +608,23 @@ export async function runFinalizeSpreadsheetPhase(
     console.log(`[SpreadsheetJob] Reduce prompt: ${prompt.length} chars`);
 
     const startTime = Date.now();
-    const response = await invokeStudioLlm({
+    const rawContent = await invokeStudioLlm({
       invoke: () =>
-        (reduceLLM as any).invoke([
-          new SystemMessage(withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language)),
-          new HumanMessage(prompt),
-        ]),
+        invokeTogetherText({
+          systemPrompt: withLanguageInstruction(REDUCE_SYSTEM_PROMPT, language),
+          userPrompt: prompt,
+          model: env.SPREADSHEET_LLM,
+          maxTokens: 32_000,
+          temperature: 0.5,
+          reasoningEnabled: true,
+        }),
       timeoutMs: CONFIG.REDUCE_TIMEOUT_MS,
       phaseLabel: "SpreadsheetReduce",
     });
 
-    const rawContent = getMessageContent(response);
     let finalOutput = cleanCsvOutput(rawContent);
 
-    // Handle truncation
-    const responseAny = response as any;
-    const metadata = responseAny.response_metadata || {};
-    const finishReason = metadata.finish_reason || metadata.tokenUsage?.finish_reason;
-
-    if (finishReason === "length") {
+    if (rawContent.length >= 31_000) {
       console.log("[SpreadsheetJob] CSV may be truncated, trimming incomplete last row");
       const lastNewline = finalOutput.lastIndexOf("\n");
       if (lastNewline > 0) {
@@ -717,6 +666,8 @@ export async function runFinalizeSpreadsheetPhase(
       spreadsheet: finalOutput,
       metadata: {
         title,
+        spreadsheetType: spreadsheetType || spreadsheet.metadata?.spreadsheetType || "custom",
+        customPrompt: customPrompt ?? spreadsheet.metadata?.customPrompt,
         phase: "completed",
         progress: 100,
         completedAt: Date.now(),
@@ -808,7 +759,6 @@ async function recursiveCollapse(
 
   console.log(`[SpreadsheetJob] Collapsing ${groups.length} token-aware groups`);
 
-  const reduceLLM = createReduceLLM();
   const collapsed = await allWithConcurrency(
     groups.map((group, idx) => {
       return async () => {
@@ -823,17 +773,19 @@ async function recursiveCollapse(
           .replace("{customPrompt}", sanitizeUserInput(customPrompt || ""));
 
         try {
-          const response = await invokeStudioLlm({
+          return await invokeStudioLlm({
             invoke: () =>
-              (reduceLLM as any).invoke([
-                new SystemMessage(withLanguageInstruction(COLLAPSE_SYSTEM_PROMPT, language)),
-                new HumanMessage(prompt),
-              ]),
+              invokeTogetherText({
+                systemPrompt: withLanguageInstruction(COLLAPSE_SYSTEM_PROMPT, language),
+                userPrompt: prompt,
+                model: env.SPREADSHEET_LLM,
+                maxTokens: 32_000,
+                temperature: 0.5,
+                reasoningEnabled: true,
+              }),
             timeoutMs: CONFIG.REDUCE_TIMEOUT_MS,
             phaseLabel: "CollapseGroup",
           });
-
-          return getMessageContent(response);
         } catch (error) {
           console.log(`[SpreadsheetJob] Collapse group ${idx} failed: ${error}`);
           return combined; // Fallback: return uncollapsed

--- a/convex/studio/writtenQuestions/writtenQuestionsJobPhases.ts
+++ b/convex/studio/writtenQuestions/writtenQuestionsJobPhases.ts
@@ -11,7 +11,6 @@ import { z } from "zod";
 import { sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
-import { createStructuredLLM } from "../../_agents/written_questions/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/WrittenQuestionsGraph";
 import {
   applySelectedQuestionIds,
@@ -26,6 +25,7 @@ import {
   WrittenQuestionsArraySchema,
   type WrittenQuestionsResponse,
 } from "../../_agents/written_questions/prompts";
+import { createStructuredLLM } from "../../_agents/written_questions/structuredLlm";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";

--- a/convex/studio/writtenQuestions/writtenQuestionsJobPhases.ts
+++ b/convex/studio/writtenQuestions/writtenQuestionsJobPhases.ts
@@ -5,14 +5,13 @@
  * @see ./job.ts for Convex `internalAction` registrations.
  */
 
-import { ChatTogetherAI } from "@langchain/community/chat_models/togetherai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import { sanitizeUserInput } from "../../_agents/_shared/index";
 import { withLanguageInstruction } from "../../_agents/_shared/languageInstruction";
-import { mergeModelKwargs } from "../../_agents/_shared/llm_factory";
 import { createErrorMetadata, createJobLogger } from "../../_agents/_shared/logging";
+import { createStructuredLLM } from "../../_agents/written_questions/structuredLlm";
 import { packChunks, validateChunks } from "../../_agents/WrittenQuestionsGraph";
 import {
   applySelectedQuestionIds,
@@ -37,39 +36,9 @@ import { invokeStudioLlm } from "../_job/invokeStudioLlm";
 // SCHEMAS
 // ============================================================
 
-// Interface for the structured LLM to avoid deep type instantiation
-interface WrittenQuestionsOutputInvoker {
-  invoke(
-    messages: Array<SystemMessage | HumanMessage>,
-    config?: any
-  ): Promise<WrittenQuestionsResponse>;
-}
-
-// Helper function to create a structured LLM without triggering deep type instantiation
-function createQuestionsLLM(llm: ChatTogetherAI): WrittenQuestionsOutputInvoker {
-  return llm.withStructuredOutput(WrittenQuestionsArraySchema, {
-    name: "written_questions",
-  });
-}
-
 const WrittenQuestionIdSelectionSchema = z.object({
   selectedIds: z.array(z.string()),
 });
-
-type WrittenQuestionIdSelectionResponse = z.infer<typeof WrittenQuestionIdSelectionSchema>;
-
-interface WrittenQuestionSelectionInvoker {
-  invoke(
-    messages: Array<SystemMessage | HumanMessage>,
-    config?: any
-  ): Promise<WrittenQuestionIdSelectionResponse>;
-}
-
-function createQuestionSelectionLLM(llm: ChatTogetherAI): WrittenQuestionSelectionInvoker {
-  return llm.withStructuredOutput(WrittenQuestionIdSelectionSchema, {
-    name: "written_question_id_selection",
-  });
-}
 
 // ============================================================
 // CONFIGURATION
@@ -118,33 +87,6 @@ export type FinalizeWrittenQuestionsPhaseArgs = {
   questionType: string;
   focus?: string;
 };
-
-// ============================================================
-// HELPER: Create structured LLM for map phase
-// ============================================================
-
-function createMapLLM(): ChatTogetherAI {
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model: env.FAST_LLM,
-    temperature: 0.4,
-    timeout: CONFIG.PER_CHUNK_TIMEOUT_MS,
-    modelKwargs: mergeModelKwargs(env.FAST_LLM, "fast"),
-    maxTokens: 8000,
-  });
-}
-
-function createReduceLLM(): ChatTogetherAI {
-  const model = env.WRITTEN_QUESTIONS_LLM;
-  return new ChatTogetherAI({
-    apiKey: env.TOGETHER_AI_API_KEY,
-    model,
-    temperature: 0.3,
-    timeout: CONFIG.REDUCE_TIMEOUT_MS,
-    maxTokens: 32_000,
-    modelKwargs: mergeModelKwargs(model, "smart"),
-  });
-}
 
 // ============================================================
 // PHASE 1: Initialize & Schedule Map Tasks
@@ -376,9 +318,12 @@ export async function runProcessWrittenQuestionsMapChunkPhase(
     }
     const language = userPrefs?.outputLanguage;
 
-    // Process with LLM using structured output
-    const llm = createMapLLM();
-    const structuredLLM = createQuestionsLLM(llm);
+    // Process with LLM using structured output (Together json_schema — same as report map)
+    const structuredLLM = createStructuredLLM(WrittenQuestionsArraySchema, {
+      model: env.FAST_LLM,
+      temperature: 0.4,
+      maxTokens: 8000,
+    });
 
     const sanitizedFocus = focus ? sanitizeUserInput(focus) : undefined;
     const prompt = getMapPrompt({
@@ -657,8 +602,15 @@ export async function runFinalizeWrittenQuestionsPhase(
         `[WrittenQuestionsJob] Selecting ${questionCount} best questions from ${dedupedQuestions.length} deduped candidates`
       );
 
-      const reduceLLM = createReduceLLM();
-      const structuredSelectLLM = createQuestionSelectionLLM(reduceLLM);
+      const structuredSelectLLM = createStructuredLLM<
+        z.infer<typeof WrittenQuestionIdSelectionSchema>
+      >(WrittenQuestionIdSelectionSchema, {
+        model: env.WRITTEN_QUESTIONS_LLM,
+        schemaName: "written_question_id_selection",
+        maxTokens: 32_000,
+        temperature: 0.3,
+        reasoningEnabled: true,
+      });
       const sanitizedFocus = focus ? sanitizeUserInput(focus) : undefined;
       const selectionPrompt = getSelectionIdsPrompt({
         questions: dedupedQuestions,


### PR DESCRIPTION
## Summary

- Add listSummary helpers so notes list queries return lightweight summary rows (counts, previews, thumbnail URLs) instead of full content payloads.
- Lazy-load full note content in StudioPanel via useNoteDetail when opening a saved note.
- Introduce shared invokeStructuredOutput for studio agents (flashcards, quizzes, mind maps, reports, written questions) with retry and json_schema fallback.
- Improve optimistic studio UI: pending generation placeholders merge with server notes in useChatStream until Convex confirms them.

## Test plan

- [x] un run typecheck:convex and un run typecheck:web
- [x] un run test:convex (structuredLlm, listSummary)
- [x] un run test:web (mergePendingStudioNotes, notesApi)
- [ ] Open Studio with many notes — list loads quickly and counts/previews look correct
- [ ] Open a saved report, flashcard deck, quiz, and mind map — full content loads after spinner
- [ ] Generate a new studio artifact — placeholder appears immediately and resolves when job completes

Made with [Cursor](https://cursor.com)