### PR TITLE
fix: redirect unauthenticated home create actions to sign-in

### DIFF
--- a/apps/web/src/features/notebooks/components/HomePage.tsx
+++ b/apps/web/src/features/notebooks/components/HomePage.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpAZ, Calendar, CheckCircle2, ChevronDown, LayoutGrid, List } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLimitErrorToast } from "@/shared/hooks/useLimitErrorToast";
 import { FolderItem, NotebookItem } from "@/shared/types/index";
 import { useFolderHandlers, useNotebookHandlers, useNotebookSorting } from "../hooks";
@@ -51,6 +51,7 @@ export const HomePage: React.FC<HomePageProps> = (_props: HomePageProps) => {
   const onDeleteFolder = ctx.deleteFolder;
   const onMoveNotebookToFolder = ctx.moveNotebookToFolder;
   const onRequireAuth = ctx.onRequireAuth;
+  const isAuthenticated = ctx.isAuthenticated;
 
   const [activeTab, setActiveTab] = useState("All");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
@@ -72,6 +73,22 @@ export const HomePage: React.FC<HomePageProps> = (_props: HomePageProps) => {
     onUpdateFolder,
     onDeleteFolder,
   });
+
+  const handleCreateNotebookClick = useCallback(() => {
+    if (!isAuthenticated) {
+      onRequireAuth("Sign in to create a notebook.");
+      return;
+    }
+    notebookHandlers.openCreateNotebook();
+  }, [isAuthenticated, onRequireAuth, notebookHandlers.openCreateNotebook]);
+
+  const handleCreateFolderClick = useCallback(() => {
+    if (!isAuthenticated) {
+      onRequireAuth("Sign in to create a folder.");
+      return;
+    }
+    folderHandlers.openCreateFolder();
+  }, [isAuthenticated, onRequireAuth, folderHandlers.openCreateFolder]);
 
   // Convex hooks for mutations
   const createNotebookHook = useCreateNotebook();
@@ -289,8 +306,8 @@ export const HomePage: React.FC<HomePageProps> = (_props: HomePageProps) => {
               recentNotebooks={sortedRecentNotebooks}
               folders={folders}
               viewMode={viewMode}
-              onCreateNotebook={notebookHandlers.openCreateNotebook}
-              onCreateFolder={folderHandlers.openCreateFolder}
+              onCreateNotebook={handleCreateNotebookClick}
+              onCreateFolder={handleCreateFolderClick}
               onSelectNotebook={onSelectNotebook}
               onSelectFolder={onSelectFolder}
               // Notebook handlers


### PR DESCRIPTION
## Summary
- Gate Create new notebook and Create new folder on /home behind an auth check
- Signed-out users (including mobile) are redirected to /sign-in instead of opening the customize modal

## Test plan
- [x] bun run typecheck:web
- [ ] Open /home while signed out on mobile viewport; tap create notebook/folder and confirm redirect to /sign-in
- [ ] Signed-in users can still open the customize modal as before

Made with [Cursor](https://cursor.com)