### PR TITLE
feat(sources): add YouTube embed preview and header link

### DIFF
--- a/apps/web/src/features/sources/components/SourceViewer.test.tsx
+++ b/apps/web/src/features/sources/components/SourceViewer.test.tsx
@@ -232,13 +232,59 @@ describe("SourceViewer source guide", () => {
       },
     });
 
-    const preview = screen.getByTestId("youtube-video-preview");
+    const guide = screen.getByRole("button", { name: /source guide/i });
+    const preview = screen.getByRole("region", { name: "YouTube video preview" });
+    expect(guide.compareDocumentPosition(preview) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
     expect(preview).toBeInTheDocument();
-    expect(preview.querySelector("iframe")).toHaveAttribute(
+    expect(screen.getByTitle("ML Lecture")).toHaveAttribute(
       "src",
-      "https://www.youtube.com/embed/dQw4w9WgXcQ"
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
     );
     expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  test("shows unavailable message when YouTube url cannot be embedded", () => {
+    const mockGenerate = vi.fn().mockResolvedValue(undefined);
+    (useGenerateSourceGuide as ReturnType<typeof vi.fn>).mockReturnValue(mockGenerate);
+
+    renderViewer({
+      source: {
+        id: "doc-yt-bad",
+        title: "Bad Link",
+        type: "YOUTUBE",
+        date: "2024-01-15",
+        selected: true,
+        status: "completed",
+        url: "https://example.com/not-youtube",
+      },
+    });
+
+    expect(screen.queryByTestId("youtube-video-preview")).not.toBeInTheDocument();
+    expect(screen.getByTestId("youtube-embed-unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open video in a new tab" })).toHaveAttribute(
+      "href",
+      "https://example.com/not-youtube"
+    );
+  });
+
+  test("shows no YouTube preview when url is missing", () => {
+    const mockGenerate = vi.fn().mockResolvedValue(undefined);
+    (useGenerateSourceGuide as ReturnType<typeof vi.fn>).mockReturnValue(mockGenerate);
+
+    renderViewer({
+      source: {
+        id: "doc-yt-no-url",
+        title: "No URL",
+        type: "YOUTUBE",
+        date: "2024-01-15",
+        selected: true,
+        status: "completed",
+      },
+    });
+
+    expect(screen.queryByTestId("youtube-video-preview")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("youtube-embed-unavailable")).not.toBeInTheDocument();
   });
 
   test("only generates once per mount", async () => {

--- a/apps/web/src/features/sources/components/SourceViewer.test.tsx
+++ b/apps/web/src/features/sources/components/SourceViewer.test.tsx
@@ -211,6 +211,36 @@ describe("SourceViewer source guide", () => {
     });
   });
 
+  test("shows YouTube embed preview below source guide for YouTube sources", () => {
+    const mockGenerate = vi.fn();
+    (useGenerateSourceGuide as ReturnType<typeof vi.fn>).mockReturnValue(mockGenerate);
+
+    renderViewer({
+      source: {
+        id: "doc-yt",
+        title: "ML Lecture",
+        type: "YOUTUBE",
+        date: "2024-01-15",
+        selected: true,
+        status: "completed",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        sourceGuide: {
+          summary: "Lecture summary.",
+          topics: ["Preprocessing"],
+          generatedAt: Date.now(),
+        },
+      },
+    });
+
+    const preview = screen.getByTestId("youtube-video-preview");
+    expect(preview).toBeInTheDocument();
+    expect(preview.querySelector("iframe")).toHaveAttribute(
+      "src",
+      "https://www.youtube.com/embed/dQw4w9WgXcQ"
+    );
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
   test("only generates once per mount", async () => {
     const mockGenerate = vi.fn().mockResolvedValue(undefined);
     (useGenerateSourceGuide as ReturnType<typeof vi.fn>).mockReturnValue(mockGenerate);

--- a/apps/web/src/features/sources/components/SourceViewer.tsx
+++ b/apps/web/src/features/sources/components/SourceViewer.tsx
@@ -13,6 +13,7 @@ import { sanitizeMarkdown } from "@/shared/utils";
 import { cn } from "@/shared/utils/cn";
 import { useGenerateSourceGuide, useGetSignedUrl } from "../services/documentsApi";
 import { PdfViewer } from "./PdfViewer";
+import { YouTubeVideoPreview } from "./YouTubeVideoPreview";
 
 const MarkdownRenderer = lazy(() =>
   import("@/shared/components/MarkdownRenderer").then((m) => ({ default: m.default }))
@@ -197,6 +198,10 @@ export const SourceViewer: React.FC<SourceViewerProps> = ({
         <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4">
           <p className="text-xs text-destructive">{guideError}</p>
         </div>
+      ) : null}
+
+      {source.type === "YOUTUBE" && source.url ? (
+        <YouTubeVideoPreview url={source.url} title={source.title} />
       ) : null}
 
       {/* Error State */}

--- a/apps/web/src/features/sources/components/SourceViewer.tsx
+++ b/apps/web/src/features/sources/components/SourceViewer.tsx
@@ -11,11 +11,11 @@ import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { Source } from "@/shared/types";
 import { sanitizeMarkdown } from "@/shared/utils";
 import { cn } from "@/shared/utils/cn";
+import { extractYouTubeVideoId } from "@/shared/utils/youtubeEmbed";
 import { useGenerateSourceGuide, useGetSignedUrl } from "../services/documentsApi";
 import { isYouTubeSource } from "../utils/sourceTypes";
 import { PdfViewer } from "./PdfViewer";
 import { YouTubeEmbedUnavailable, YouTubeVideoPreview } from "./YouTubeVideoPreview";
-import { extractYouTubeVideoId } from "@/shared/utils/youtubeEmbed";
 
 const MarkdownRenderer = lazy(() =>
   import("@/shared/components/MarkdownRenderer").then((m) => ({ default: m.default }))
@@ -105,8 +105,7 @@ export const SourceViewer: React.FC<SourceViewerProps> = ({
     generateSourceGuide,
   ]);
 
-  const youtubeVideoId =
-    isYouTubeSource(source) ? extractYouTubeVideoId(source.url) : null;
+  const youtubeVideoId = isYouTubeSource(source) ? extractYouTubeVideoId(source.url) : null;
 
   return (
     <div className="p-6 space-y-4 animate-in fade-in slide-in-from-right-4 duration-200">
@@ -207,11 +206,7 @@ export const SourceViewer: React.FC<SourceViewerProps> = ({
 
       {isYouTubeSource(source) ? (
         youtubeVideoId ? (
-          <YouTubeVideoPreview
-            key={youtubeVideoId}
-            videoId={youtubeVideoId}
-            title={source.title}
-          />
+          <YouTubeVideoPreview key={youtubeVideoId} videoId={youtubeVideoId} title={source.title} />
         ) : (
           <YouTubeEmbedUnavailable url={source.url} />
         )

--- a/apps/web/src/features/sources/components/SourceViewer.tsx
+++ b/apps/web/src/features/sources/components/SourceViewer.tsx
@@ -12,8 +12,10 @@ import { Source } from "@/shared/types";
 import { sanitizeMarkdown } from "@/shared/utils";
 import { cn } from "@/shared/utils/cn";
 import { useGenerateSourceGuide, useGetSignedUrl } from "../services/documentsApi";
+import { isYouTubeSource } from "../utils/sourceTypes";
 import { PdfViewer } from "./PdfViewer";
-import { YouTubeVideoPreview } from "./YouTubeVideoPreview";
+import { YouTubeEmbedUnavailable, YouTubeVideoPreview } from "./YouTubeVideoPreview";
+import { extractYouTubeVideoId } from "@/shared/utils/youtubeEmbed";
 
 const MarkdownRenderer = lazy(() =>
   import("@/shared/components/MarkdownRenderer").then((m) => ({ default: m.default }))
@@ -102,6 +104,9 @@ export const SourceViewer: React.FC<SourceViewerProps> = ({
     guideError,
     generateSourceGuide,
   ]);
+
+  const youtubeVideoId =
+    isYouTubeSource(source) ? extractYouTubeVideoId(source.url) : null;
 
   return (
     <div className="p-6 space-y-4 animate-in fade-in slide-in-from-right-4 duration-200">
@@ -200,8 +205,16 @@ export const SourceViewer: React.FC<SourceViewerProps> = ({
         </div>
       ) : null}
 
-      {source.type === "YOUTUBE" && source.url ? (
-        <YouTubeVideoPreview url={source.url} title={source.title} />
+      {isYouTubeSource(source) ? (
+        youtubeVideoId ? (
+          <YouTubeVideoPreview
+            key={youtubeVideoId}
+            videoId={youtubeVideoId}
+            title={source.title}
+          />
+        ) : (
+          <YouTubeEmbedUnavailable url={source.url} />
+        )
       ) : null}
 
       {/* Error State */}

--- a/apps/web/src/features/sources/components/SourcesPanelHeader.test.tsx
+++ b/apps/web/src/features/sources/components/SourcesPanelHeader.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, test, vi } from "vitest";
+import type { Source } from "@/shared/types";
+import { SourcesPanelHeader } from "./SourcesPanelHeader";
+
+function renderHeader(overrides: Partial<ComponentProps<typeof SourcesPanelHeader>> = {}) {
+  const viewingSource: Source = {
+    id: "doc-yt",
+    title: "ML Lecture",
+    type: "YOUTUBE",
+    date: "2024-01-15",
+    selected: true,
+    status: "completed",
+    url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  };
+
+  const props: ComponentProps<typeof SourcesPanelHeader> = {
+    viewingSource,
+    onBackToList: vi.fn(),
+    onEnterRename: vi.fn(),
+    onExitRename: vi.fn(),
+    onClose: vi.fn(),
+    selectedCount: 1,
+    onCopy: vi.fn(),
+    onDownload: vi.fn(),
+    canCopyOrDownload: true,
+    isRenaming: false,
+    renameValue: viewingSource.title,
+    onRenameChange: vi.fn(),
+    onRenameSubmit: vi.fn(),
+    onResizeStart: vi.fn(),
+    ...overrides,
+  };
+
+  return render(<SourcesPanelHeader {...props} />);
+}
+
+describe("SourcesPanelHeader external link", () => {
+  test("shows external link for YouTube sources on mobile and desktop", () => {
+    renderHeader();
+
+    const links = screen.getAllByRole("link", { name: "Open source in new tab" });
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  test("hides external link when YouTube source has no url", () => {
+    renderHeader({
+      viewingSource: {
+        id: "doc-yt",
+        title: "ML Lecture",
+        type: "YOUTUBE",
+        date: "2024-01-15",
+        selected: true,
+        status: "completed",
+      },
+    });
+
+    expect(screen.queryByRole("link", { name: "Open source in new tab" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
+++ b/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, Copy, Download, ExternalLink, FileStack } from "lucide-react";
 import React from "react";
 import { Source } from "@/shared/types";
+import { hasExternalSourceUrl } from "../utils/sourceTypes";
 
 interface SourcesPanelHeaderProps {
   viewingSource: Source | null;
@@ -108,10 +109,7 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 shrink-0">
-                {(viewingSource.type === "WEB" ||
-                  viewingSource.type === "PAPER" ||
-                  viewingSource.type === "YOUTUBE") &&
-                  viewingSource.url && (
+                {hasExternalSourceUrl(viewingSource) && (
                     <a
                       href={viewingSource.url}
                       target="_blank"
@@ -221,10 +219,7 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 shrink-0">
-                {(viewingSource.type === "WEB" ||
-                  viewingSource.type === "PAPER" ||
-                  viewingSource.type === "YOUTUBE") &&
-                  viewingSource.url && (
+                {hasExternalSourceUrl(viewingSource) && (
                     <a
                       href={viewingSource.url}
                       target="_blank"

--- a/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
+++ b/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
@@ -110,17 +110,17 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 {hasExternalSourceUrl(viewingSource) && (
-                    <a
-                      href={viewingSource.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="p-2 rounded-md text-foreground/70 hover:text-foreground hover:bg-secondary transition-colors touch-manipulation"
-                      title="Open in new tab"
-                      aria-label="Open source in new tab"
-                    >
-                      <ExternalLink className="w-4 h-4" />
-                    </a>
-                  )}
+                  <a
+                    href={viewingSource.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 rounded-md text-foreground/70 hover:text-foreground hover:bg-secondary transition-colors touch-manipulation"
+                    title="Open in new tab"
+                    aria-label="Open source in new tab"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                )}
                 <button
                   type="button"
                   onClick={onCopy}
@@ -220,17 +220,17 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 {hasExternalSourceUrl(viewingSource) && (
-                    <a
-                      href={viewingSource.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="p-2 rounded-sm text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors touch-manipulation"
-                      title="Open in new tab"
-                      aria-label="Open source in new tab"
-                    >
-                      <ExternalLink className="w-4 h-4" />
-                    </a>
-                  )}
+                  <a
+                    href={viewingSource.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 rounded-sm text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors touch-manipulation"
+                    title="Open in new tab"
+                    aria-label="Open source in new tab"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                )}
                 <button
                   type="button"
                   onClick={onCopy}

--- a/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
+++ b/apps/web/src/features/sources/components/SourcesPanelHeader.tsx
@@ -108,7 +108,9 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 shrink-0">
-                {(viewingSource.type === "WEB" || viewingSource.type === "PAPER") &&
+                {(viewingSource.type === "WEB" ||
+                  viewingSource.type === "PAPER" ||
+                  viewingSource.type === "YOUTUBE") &&
                   viewingSource.url && (
                     <a
                       href={viewingSource.url}
@@ -219,7 +221,9 @@ export const SourcesPanelHeader: React.FC<SourcesPanelHeaderProps> = ({
                 </div>
               </div>
               <div className="flex items-center gap-1 shrink-0">
-                {(viewingSource.type === "WEB" || viewingSource.type === "PAPER") &&
+                {(viewingSource.type === "WEB" ||
+                  viewingSource.type === "PAPER" ||
+                  viewingSource.type === "YOUTUBE") &&
                   viewingSource.url && (
                     <a
                       href={viewingSource.url}

--- a/apps/web/src/features/sources/components/YouTubeVideoPreview.tsx
+++ b/apps/web/src/features/sources/components/YouTubeVideoPreview.tsx
@@ -1,14 +1,14 @@
-import { extractYouTubeVideoId, youTubeEmbedSrc } from "@/shared/utils/youtubeEmbed";
+import { youTubeEmbedSrc } from "@/shared/utils/youtubeEmbed";
 
 interface YouTubeVideoPreviewProps {
-  url: string;
+  videoId: string;
   title?: string;
 }
 
-export function YouTubeVideoPreview({ url, title = "YouTube video" }: YouTubeVideoPreviewProps) {
-  const videoId = extractYouTubeVideoId(url);
-  if (!videoId) return null;
-
+export function YouTubeVideoPreview({
+  videoId,
+  title = "YouTube video",
+}: YouTubeVideoPreviewProps) {
   return (
     <section
       aria-label="YouTube video preview"
@@ -19,11 +19,38 @@ export function YouTubeVideoPreview({ url, title = "YouTube video" }: YouTubeVid
         <iframe
           src={youTubeEmbedSrc(videoId)}
           title={title}
+          loading="lazy"
           className="absolute inset-0 h-full w-full border-0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowFullScreen
         />
       </div>
+    </section>
+  );
+}
+
+interface YouTubeEmbedUnavailableProps {
+  url: string;
+}
+
+export function YouTubeEmbedUnavailable({ url }: YouTubeEmbedUnavailableProps) {
+  return (
+    <section
+      aria-label="YouTube video preview unavailable"
+      className="rounded-2xl border border-border/60 bg-muted/20 p-4"
+      data-testid="youtube-embed-unavailable"
+    >
+      <p className="text-sm text-muted-foreground">
+        This YouTube link couldn&apos;t be embedded.{" "}
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+        >
+          Open video in a new tab
+        </a>
+      </p>
     </section>
   );
 }

--- a/apps/web/src/features/sources/components/YouTubeVideoPreview.tsx
+++ b/apps/web/src/features/sources/components/YouTubeVideoPreview.tsx
@@ -1,0 +1,29 @@
+import { extractYouTubeVideoId, youTubeEmbedSrc } from "@/shared/utils/youtubeEmbed";
+
+interface YouTubeVideoPreviewProps {
+  url: string;
+  title?: string;
+}
+
+export function YouTubeVideoPreview({ url, title = "YouTube video" }: YouTubeVideoPreviewProps) {
+  const videoId = extractYouTubeVideoId(url);
+  if (!videoId) return null;
+
+  return (
+    <section
+      aria-label="YouTube video preview"
+      className="overflow-hidden rounded-2xl border border-border/60 bg-card shadow-sm ring-1 ring-border/30"
+      data-testid="youtube-video-preview"
+    >
+      <div className="relative aspect-video w-full bg-muted">
+        <iframe
+          src={youTubeEmbedSrc(videoId)}
+          title={title}
+          className="absolute inset-0 h-full w-full border-0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/sources/utils/sourceTypes.ts
+++ b/apps/web/src/features/sources/utils/sourceTypes.ts
@@ -1,0 +1,16 @@
+import type { Source } from "@/shared/types";
+
+export type YouTubeSource = Source & { type: "YOUTUBE"; url: string };
+
+export function isYouTubeSource(source: Source): source is YouTubeSource {
+  return source.type === "YOUTUBE" && Boolean(source.url);
+}
+
+export function hasExternalSourceUrl(
+  source: Source
+): source is Source & { url: string } {
+  return (
+    (source.type === "WEB" || source.type === "PAPER" || source.type === "YOUTUBE") &&
+    Boolean(source.url)
+  );
+}

--- a/apps/web/src/features/sources/utils/sourceTypes.ts
+++ b/apps/web/src/features/sources/utils/sourceTypes.ts
@@ -6,9 +6,7 @@ export function isYouTubeSource(source: Source): source is YouTubeSource {
   return source.type === "YOUTUBE" && Boolean(source.url);
 }
 
-export function hasExternalSourceUrl(
-  source: Source
-): source is Source & { url: string } {
+export function hasExternalSourceUrl(source: Source): source is Source & { url: string } {
   return (
     (source.type === "WEB" || source.type === "PAPER" || source.type === "YOUTUBE") &&
     Boolean(source.url)

--- a/apps/web/src/shared/utils/youtubeEmbed.test.ts
+++ b/apps/web/src/shared/utils/youtubeEmbed.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  extractYouTubeVideoId,
-  isYouTubeHostname,
-  youTubeEmbedSrc,
-} from "./youtubeEmbed";
+import { extractYouTubeVideoId, isYouTubeHostname, youTubeEmbedSrc } from "./youtubeEmbed";
 
 describe("isYouTubeHostname", () => {
   it("accepts youtube.com and subdomains", () => {

--- a/apps/web/src/shared/utils/youtubeEmbed.test.ts
+++ b/apps/web/src/shared/utils/youtubeEmbed.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractYouTubeVideoId,
+  isYouTubeHostname,
+  youTubeEmbedSrc,
+} from "./youtubeEmbed";
+
+describe("isYouTubeHostname", () => {
+  it("accepts youtube.com and subdomains", () => {
+    expect(isYouTubeHostname("www.youtube.com")).toBe(true);
+    expect(isYouTubeHostname("m.youtube.com")).toBe(true);
+    expect(isYouTubeHostname("youtube.com")).toBe(true);
+  });
+
+  it("accepts youtu.be", () => {
+    expect(isYouTubeHostname("youtu.be")).toBe(true);
+  });
+
+  it("rejects non-YouTube hosts", () => {
+    expect(isYouTubeHostname("evil.com")).toBe(false);
+    expect(isYouTubeHostname("notyoutube.com")).toBe(false);
+  });
+});
+
+describe("extractYouTubeVideoId", () => {
+  it("parses watch URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/watch?v=abc123")).toBe("abc123");
+  });
+
+  it("parses youtu.be URLs", () => {
+    expect(extractYouTubeVideoId("https://youtu.be/abc123")).toBe("abc123");
+  });
+
+  it("parses shorts URLs", () => {
+    expect(extractYouTubeVideoId("https://youtube.com/shorts/abc123")).toBe("abc123");
+  });
+
+  it("parses embed URLs", () => {
+    expect(extractYouTubeVideoId("https://youtube.com/embed/abc123")).toBe("abc123");
+  });
+
+  it("parses live URLs", () => {
+    expect(extractYouTubeVideoId("https://youtube.com/live/abc123")).toBe("abc123");
+  });
+
+  it("returns null for empty or invalid input", () => {
+    expect(extractYouTubeVideoId("")).toBeNull();
+    expect(extractYouTubeVideoId(undefined)).toBeNull();
+    expect(extractYouTubeVideoId("not-a-url")).toBeNull();
+  });
+
+  it("rejects non-YouTube hosts even when v= is present", () => {
+    expect(extractYouTubeVideoId("https://evil.com/watch?v=abc123")).toBeNull();
+    expect(extractYouTubeVideoId("https://phishing.example/watch?v=dQw4w9WgXcQ")).toBeNull();
+  });
+
+  it("rejects javascript and data URLs", () => {
+    expect(extractYouTubeVideoId("javascript:alert(1)")).toBeNull();
+    expect(extractYouTubeVideoId("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+});
+
+describe("youTubeEmbedSrc", () => {
+  it("builds a nocookie embed URL with the video id", () => {
+    expect(youTubeEmbedSrc("abc123")).toBe("https://www.youtube-nocookie.com/embed/abc123");
+  });
+});

--- a/apps/web/src/shared/utils/youtubeEmbed.ts
+++ b/apps/web/src/shared/utils/youtubeEmbed.ts
@@ -1,28 +1,51 @@
+const YOUTUBE_VIDEO_ID = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * True for youtube.com, m.youtube.com, www.youtube.com, youtu.be, etc.
+ */
+export function isYouTubeHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === "youtu.be" || host === "youtube.com" || host.endsWith(".youtube.com");
+}
+
 /**
  * Extract YouTube video ID from common watch/share/embed URL shapes.
+ * Only accepts URLs on YouTube hostnames (rejects arbitrary sites with a `v=` query param).
  */
 export function extractYouTubeVideoId(url: string | undefined): string | null {
   if (!url?.trim()) return null;
-  const u = url.trim();
 
-  const youtuBe = u.match(/youtu\.be\/([a-zA-Z0-9_-]+)/);
-  if (youtuBe) return youtuBe[1];
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return null;
+  }
 
-  const shorts = u.match(/youtube\.com\/shorts\/([a-zA-Z0-9_-]+)/);
+  if (!isYouTubeHostname(parsed.hostname)) return null;
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (host === "youtu.be") {
+    const id = parsed.pathname.slice(1).split("/")[0];
+    return id && YOUTUBE_VIDEO_ID.test(id) ? id : null;
+  }
+
+  const shorts = parsed.pathname.match(/^\/shorts\/([a-zA-Z0-9_-]+)/);
   if (shorts) return shorts[1];
 
-  const embed = u.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]+)/);
+  const embed = parsed.pathname.match(/^\/embed\/([a-zA-Z0-9_-]+)/);
   if (embed) return embed[1];
 
-  const live = u.match(/youtube\.com\/live\/([a-zA-Z0-9_-]+)/);
+  const live = parsed.pathname.match(/^\/live\/([a-zA-Z0-9_-]+)/);
   if (live) return live[1];
 
-  const watchV = u.match(/[?&]v=([a-zA-Z0-9_-]+)/);
-  if (watchV) return watchV[1];
+  const watchId = parsed.searchParams.get("v");
+  if (watchId && YOUTUBE_VIDEO_ID.test(watchId)) return watchId;
 
   return null;
 }
 
 export function youTubeEmbedSrc(videoId: string): string {
-  return `https://www.youtube.com/embed/${videoId}`;
+  return `https://www.youtube-nocookie.com/embed/${videoId}`;
 }


### PR DESCRIPTION
## Summary
- Add a responsive YouTube embed preview below the source guide when viewing a YouTube source
- Show the external-link icon in the sources panel header for YouTube sources (same as web and paper)

## Test plan
- [x] bun run typecheck:web
- [x] bun run test:web -- src/features/sources/components/SourceViewer.test.tsx
- [ ] Open a YouTube source in the notebook sources panel and confirm the embed appears below the source guide
- [ ] Confirm the header external-link icon opens the original YouTube URL in a new tab

Made with [Cursor](https://cursor.com)